### PR TITLE
feat(devops): Docker containerization - Sprint 03 (DO-3.1~DO-3.4)

### DIFF
--- a/.agents/skills/temuin-qa-docs/SKILL.md
+++ b/.agents/skills/temuin-qa-docs/SKILL.md
@@ -15,7 +15,7 @@ description: Gunakan saat mengerjakan role QA & Docs di project Temuin. Skill in
 
 - Fokus pada blackbox flow
 - Simpan screenshot bukti seperlunya
-- Jangan membuat issue tracker formal atau bug template formal
+- Gunakan GitHub Issues untuk tracking sprint completion (lihat skill `temuin-sprint-issue`)
 - Update dokumen aktif hanya jika flow atau langkah berubah
 - Update status task sesuai aturan repo
 - Setiap sprint yang sudah selesai di-QA wajib punya satu file report di `docs/`

--- a/.agents/skills/temuin-sprint-issue/SKILL.md
+++ b/.agents/skills/temuin-sprint-issue/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: temuin-sprint-issue
+description: Gunakan setelah menyelesaikan sprint untuk membuat GitHub Issue sebagai laporan sprint completion. Skill ini mendefinisikan format konsisten untuk semua role.
+---
+
+# Temuin Sprint Issue
+
+Skill ini digunakan setelah semua task dalam satu sprint untuk suatu role sudah `done` (committed dan pushed). Buat satu GitHub Issue per role per sprint sebagai catatan resmi.
+
+## Kapan Digunakan
+
+- Setelah semua task sprint untuk role tertentu sudah `done`
+- Setelah PR sudah dibuat (atau sudah merged)
+- Berlaku untuk **semua role**: backend, frontend, devops, QA
+
+## Format Issue
+
+### Title
+
+```
+[Sprint XX] <Role>: <Task IDs> — <Ringkasan Singkat>
+```
+
+Contoh:
+- `[Sprint 03] DevOps: DO-3.1~DO-3.4 — Docker containerization`
+- `[Sprint 02] Backend: BE-2.1~BE-2.4 — Auth flow dan item CRUD`
+- `[Sprint 02] QA: QA-2.1~QA-2.4 — Blackbox testing auth & items`
+- `[Sprint 01] Frontend: FE-1.1~FE-1.4 — Scaffold React + Vite + shadcn`
+
+### Labels
+
+Gunakan label sesuai role:
+- `devops` untuk DevOps
+- `backend` untuk Backend
+- `frontend` untuk Frontend
+- `qa` untuk QA & Docs
+- Tambah `documentation` jika isi issue lebih ke dokumentasi
+
+### Body Template
+
+```markdown
+## Ringkasan
+
+Dokumentasi kerja <Role> (@username) untuk Sprint XX.
+
+| Task ID | Deskripsi | Status | Branch / PR |
+|---------|-----------|--------|-------------|
+| XX-X.1  | ...       | done   | `feat/...` / PR #XX |
+| XX-X.2  | ...       | done   | `feat/...` / PR #XX |
+
+---
+
+## Detail Per Task
+
+### XX-X.1 — <Nama Task>
+
+**Deskripsi:** Apa yang diminta task ini.
+
+**Yang Dikerjakan:**
+- Poin-poin konkret apa yang dilakukan
+- File atau komponen utama yang dibuat/diubah
+
+**Acceptance Criteria:**
+- [x] Kriteria 1
+- [x] Kriteria 2
+- [ ] Kriteria yang belum terpenuhi (jelaskan alasan)
+
+**Referensi:**
+- Decision log: DEC-XXX
+- Dokumen: `temuin-docs/path/to/doc.md`
+- PR: #XX
+
+---
+
+*(Ulangi section untuk setiap task)*
+
+## Files Changed
+
+<details>
+<summary>Daftar file yang berubah (klik untuk expand)</summary>
+
+- `path/to/file1.ext` — deskripsi singkat
+- `path/to/file2.ext` — deskripsi singkat
+
+</details>
+
+## Verifikasi
+
+- [x] Semua task sudah `done` di sprint file
+- [x] Branch sudah di-push ke remote
+- [x] PR sudah dibuat
+- [x] (Tambahan sesuai role, contoh: Docker images pushed, tests passed, dll.)
+
+## Status Sprint XX (<Role>)
+
+Sprint XX untuk role <Role> sudah **selesai**.
+
+*(Catatan tambahan jika ada task yang blocked atau carry-over ke sprint berikutnya)*
+```
+
+## Cara Membuat Issue
+
+### Via GitHub CLI
+
+```bash
+gh issue create \
+  --title "[Sprint XX] Role: IDs — Summary" \
+  --label "role-label" \
+  --body-file path/to/body.md
+```
+
+### Via GitHub Web UI
+
+Buat issue baru di tab Issues, ikuti format di atas.
+
+## Panduan Penulisan
+
+- **Bahasa**: Bahasa Indonesia untuk isi, heading boleh campuran
+- **Detail**: Tulis cukup detail agar bisa menjawab pertanyaan dosen tentang apa yang dikerjakan
+- **Checklist**: Gunakan `[x]` dan `[ ]` untuk acceptance criteria
+- **Referensi**: Link ke decision log, dokumen arsitektur, atau PR yang relevan
+- **Satu issue per role per sprint**: Jangan gabung beberapa role dalam satu issue
+
+## Referensi Workflow
+
+- Commit convention: `temuin-docs/04-implementation-plan/commit-convention.md`
+- Branching strategy: `temuin-docs/04-implementation-plan/branching-strategy.md`
+- Development workflow: `temuin-docs/04-implementation-plan/development-workflow.md`
+- Contoh issue yang baik: #25, #26 (DevOps Sprint 01-02)

--- a/.env.docker
+++ b/.env.docker
@@ -15,7 +15,7 @@ DB_NAME=temuin_db
 DB_PORT=5434
 
 # --- Backend ---
-SECRET_KEY=914a8ba2e4bde50f9fb4e33da139801975f59c2b2c955fec1b9ba3bc6c6b65
+SECRET_KEY=CHANGE_ME_run_python_c_import_secrets_print_secrets_token_hex_32
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=60
 CORS_ORIGINS=["http://localhost:3000","http://localhost:5173"]

--- a/.env.docker
+++ b/.env.docker
@@ -1,0 +1,31 @@
+# ============================================================
+# TEMUIN - Docker Compose Environment Configuration
+# ============================================================
+# Salin file ini ke .env lalu isi nilainya:
+#   cp .env.docker .env       (Linux/Mac)
+#   copy .env.docker .env     (Windows)
+#
+# JANGAN commit file .env ke Git!
+# ============================================================
+
+# --- Database ---
+DB_USER=postgres
+DB_PASSWORD=postgres123
+DB_NAME=temuin_db
+DB_PORT=5434
+
+# --- Backend ---
+SECRET_KEY=914a8ba2e4bde50f9fb4e33da139801975f59c2b2c955fec1b9ba3bc6c6b65
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=60
+CORS_ORIGINS=["http://localhost:3000","http://localhost:5173"]
+FIREBASE_CREDENTIALS_FILE=/app/serviceAccountKey.json
+
+# --- Frontend (Build Args - VITE_* baked at build time) ---
+VITE_API_BASE_URL=http://localhost:8000
+VITE_FIREBASE_API_KEY=your_firebase_api_key
+VITE_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=your-project-id
+VITE_FIREBASE_STORAGE_BUCKET=your-project.firebasestorage.app
+VITE_FIREBASE_MESSAGING_SENDER_ID=123456789
+VITE_FIREBASE_APP_ID=1:123456789:web:abcdef

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Ensure shell scripts always use LF line endings (required for Linux containers)
+*.sh text eol=lf
+entrypoint.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ coverage/
 .env
 .env.*
 !.env.example
+!.env.docker
 
 # Logs
 *.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Setiap AI coding agent wajib mulai dari file ini sebelum mengerjakan apa pun di 
 - PR dibuat sebagai draft; user yang memutuskan kapan ready for review
 - Frontend wajib memakai `React + Vite + Tailwind CSS + shadcn/ui`
 - Saat agent membangun UI, utamakan komponen dan pola shadcn/ui sebelum membuat markup custom
+- `temuin-docs/` hanya untuk dokumen arsitektur, sprint, dan role guide — jangan tambah file baru kecuali benar-benar perlu (seperti update status sprint). Guides, reports, dan dokumen kerja lainnya masuk ke `docs/`
 
 ## Task Tracking Rules
 - Status task yang valid hanya `todo`, `in_progress`, `blocked`, `done`
@@ -36,7 +37,7 @@ Setiap AI coding agent wajib mulai dari file ini sebelum mengerjakan apa pun di 
 
 ## QA and Documentation Rules
 - QA fokus pada blackbox testing, screenshot bukti, dan update dokumentasi seperlunya
-- Jangan menambah issue tracker formal, bug template, atau dokumen known issues yang berat
+- Gunakan GitHub Issues untuk tracking sprint completion dan bug reports (lihat `.agents/skills/temuin-sprint-issue/` untuk format)
 - Jika behavior berubah, update dokumen aktif yang relevan di `temuin-docs/`
 
 ## Workspace Skills

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,41 @@
+# Virtual environment
+venv/
+.venv/
+
+# Environment files (secrets!)
+.env
+.env.local
+.env.docker
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.mypy_cache/
+
+# IDE
+.vscode/
+.idea/
+
+# Git
+.git/
+.gitignore
+
+# Docker (don't copy Dockerfile into image)
+Dockerfile
+.dockerignore
+
+# Testing
+tests/
+
+# Documentation
+*.md
+
+# Firebase credentials (mounted at runtime, never baked into image)
+serviceAccountKey.json
+
+# OS artifacts
+*.log
+.DS_Store
+Thumbs.db

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -52,11 +52,10 @@ ENV PATH="/opt/venv/bin:$PATH"
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
-# Copy application code
+# Copy application code (includes entrypoint.sh)
 COPY . .
 
-# Copy and set entrypoint
-COPY entrypoint.sh /app/entrypoint.sh
+# Make entrypoint executable
 RUN chmod +x /app/entrypoint.sh
 
 # Security: run as non-root user

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,71 @@
+# ============================================================
+# Multi-Stage Build: Temuin Backend (FastAPI + PostgreSQL)
+# ============================================================
+# Stage 1: Builder - Install dependencies on Alpine
+# Stage 2: Production - Copy only runtime files
+# ============================================================
+
+# ============================================================
+# Stage 1: Builder
+# ============================================================
+FROM python:3.12-alpine AS builder
+
+# Build dependencies for psycopg2-binary, cryptography, etc.
+RUN apk add --no-cache \
+    gcc \
+    musl-dev \
+    libffi-dev \
+    postgresql-dev
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+# Create venv and install dependencies
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+RUN pip install --no-cache-dir --no-compile -r requirements.txt
+
+# Cleanup: remove pip/setuptools/wheel, __pycache__, .pyc, tests, docs
+RUN pip uninstall -y pip setuptools wheel 2>/dev/null || true && \
+    find /opt/venv -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true && \
+    find /opt/venv -type f -name "*.pyc" -delete 2>/dev/null || true && \
+    find /opt/venv -type d -name "tests" -exec rm -rf {} + 2>/dev/null || true && \
+    find /opt/venv -type d -name "test" -exec rm -rf {} + 2>/dev/null || true
+
+# ============================================================
+# Stage 2: Production
+# ============================================================
+FROM python:3.12-alpine
+
+# Runtime dependencies only
+RUN apk add --no-cache libpq postgresql-client
+
+WORKDIR /app
+
+# Copy venv from builder
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Disable bytecode generation and enable unbuffered output
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+# Copy application code
+COPY . .
+
+# Copy and set entrypoint
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+# Security: run as non-root user
+RUN adduser -D appuser && chown -R appuser:appuser /app
+USER appuser
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=3)"
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# ============================================================
+# Temuin Backend Entrypoint
+# 1. Wait for PostgreSQL to be ready
+# 2. Run Alembic migrations
+# 3. Start uvicorn
+# ============================================================
+
+set -e
+
+echo "=== Temuin Backend Starting ==="
+
+# --- Wait for PostgreSQL ---
+echo "Waiting for PostgreSQL..."
+MAX_RETRIES=30
+RETRY_COUNT=0
+
+while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+    if pg_isready -h "${DB_HOST:-temuin-db}" -p "${DB_PORT:-5432}" -U "${DB_USER:-postgres}" > /dev/null 2>&1; then
+        echo "PostgreSQL is ready!"
+        break
+    fi
+    RETRY_COUNT=$((RETRY_COUNT + 1))
+    echo "  Waiting for PostgreSQL... ($RETRY_COUNT/$MAX_RETRIES)"
+    sleep 2
+done
+
+if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
+    echo "WARNING: PostgreSQL not ready after $MAX_RETRIES retries. Starting anyway..."
+fi
+
+# --- Run Alembic Migrations ---
+echo "Running Alembic migrations..."
+if alembic upgrade head; then
+    echo "Migrations completed successfully."
+else
+    echo "WARNING: Alembic migration failed. Starting app anyway..."
+fi
+
+# --- Check Firebase credentials ---
+if [ -f "/app/serviceAccountKey.json" ]; then
+    echo "Firebase credentials found."
+else
+    echo "WARNING: serviceAccountKey.json not found. Firebase auth will not work."
+fi
+
+# --- Start Uvicorn ---
+echo "Starting uvicorn on 0.0.0.0:8000..."
+exec uvicorn app.main:app --host 0.0.0.0 --port 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,89 @@
+# ============================================================
+# Temuin - Docker Compose (Monolith)
+# ============================================================
+# Services: PostgreSQL + FastAPI Backend + React Frontend
+# Usage:    docker compose up -d
+# Docs:     temuin-docs/05-roles/devops.md
+# ============================================================
+
+services:
+  # --- PostgreSQL Database ---
+  db:
+    image: postgres:16-alpine
+    container_name: temuin-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${DB_USER:-postgres}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-postgres123}
+      POSTGRES_DB: ${DB_NAME:-temuin_db}
+    ports:
+      - "${DB_PORT:-5434}:5432"
+    volumes:
+      - temuin_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-postgres} -d ${DB_NAME:-temuin_db}"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    networks:
+      - temuin-net
+
+  # --- FastAPI Backend ---
+  backend:
+    image: pangeransilaen/temuin-backend:latest
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: temuin-backend
+    restart: unless-stopped
+    environment:
+      DATABASE_URL: postgresql://${DB_USER:-postgres}:${DB_PASSWORD:-postgres123}@temuin-db:5432/${DB_NAME:-temuin_db}
+      SECRET_KEY: ${SECRET_KEY:-change-me-in-production}
+      ALGORITHM: ${ALGORITHM:-HS256}
+      ACCESS_TOKEN_EXPIRE_MINUTES: ${ACCESS_TOKEN_EXPIRE_MINUTES:-60}
+      CORS_ORIGINS: ${CORS_ORIGINS:-["http://localhost:3000","http://localhost:5173"]}
+      FIREBASE_CREDENTIALS_FILE: ${FIREBASE_CREDENTIALS_FILE:-/app/serviceAccountKey.json}
+      DB_HOST: temuin-db
+      DB_PORT: "5432"
+      DB_USER: ${DB_USER:-postgres}
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./backend/serviceAccountKey.json:/app/serviceAccountKey.json:ro
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - temuin-net
+
+  # --- React Frontend (Nginx) ---
+  frontend:
+    image: pangeransilaen/temuin-frontend:latest
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:8000}
+        VITE_FIREBASE_API_KEY: ${VITE_FIREBASE_API_KEY:-}
+        VITE_FIREBASE_AUTH_DOMAIN: ${VITE_FIREBASE_AUTH_DOMAIN:-}
+        VITE_FIREBASE_PROJECT_ID: ${VITE_FIREBASE_PROJECT_ID:-}
+        VITE_FIREBASE_STORAGE_BUCKET: ${VITE_FIREBASE_STORAGE_BUCKET:-}
+        VITE_FIREBASE_MESSAGING_SENDER_ID: ${VITE_FIREBASE_MESSAGING_SENDER_ID:-}
+        VITE_FIREBASE_APP_ID: ${VITE_FIREBASE_APP_ID:-}
+    container_name: temuin-frontend
+    restart: unless-stopped
+    ports:
+      - "3000:80"
+    depends_on:
+      - backend
+    networks:
+      - temuin-net
+
+volumes:
+  temuin_pgdata:
+    name: temuin_pgdata
+
+networks:
+  temuin-net:
+    name: temuin-net
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,8 @@ services:
     ports:
       - "3000:80"
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     networks:
       - temuin-net
 

--- a/docs/docker-guide.md
+++ b/docs/docker-guide.md
@@ -1,0 +1,115 @@
+# Docker Guide — Temuin
+
+Panduan lengkap Docker workflow untuk tim Temuin.
+
+## Overview
+
+Temuin menggunakan Docker Compose untuk menjalankan tiga service:
+- **PostgreSQL** (database)
+- **FastAPI Backend** (Python)
+- **React Frontend** (Vite build, served via Nginx)
+
+Images sudah tersedia di Docker Hub — kebanyakan anggota tim **tidak perlu build sendiri**.
+
+## Prerequisites
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) (terbaru) sudah terinstall dan running
+
+## Quick Start (Untuk Semua Anggota Tim)
+
+```powershell
+# 1. Pull images terbaru dari Docker Hub
+.\scripts\temuin.ps1 pull
+
+# 2. Start semua service
+.\scripts\temuin.ps1 start
+
+# 3. Buka browser
+#    Frontend:  http://localhost:3000
+#    Backend:   http://localhost:8000
+#    API Docs:  http://localhost:8000/docs
+```
+
+## Setup Pertama Kali
+
+1. **Copy environment template:**
+   ```powershell
+   copy .env.docker .env        # Windows
+   cp .env.docker .env          # Linux/Mac
+   ```
+
+2. **Edit `.env`** — isi Firebase config dari Firebase Console (opsional, app tetap jalan tanpa ini tapi login tidak bisa)
+
+3. **Firebase credentials** (opsional):
+   Taruh `serviceAccountKey.json` di folder `backend/`. File ini sudah di-`.gitignore`. Jika tidak ada, script akan membuat placeholder kosong dan app tetap start (tapi Firebase auth tidak berfungsi).
+
+## Workflow: Anggota Tim (Backend/Frontend Dev)
+
+```
+1. Pull images terbaru     →  .\scripts\temuin.ps1 pull
+2. Start containers        →  .\scripts\temuin.ps1 start
+3. Kerjakan code lokal     →  (dev server frontend/backend masing-masing)
+4. Selesai? Push ke GitHub →  git push, buat PR
+```
+
+Kamu **tidak perlu build Docker images**. Cukup pull dan start. Docker di sini untuk menjalankan environment lengkap (database + backend + frontend) agar bisa testing integrasi.
+
+## Workflow: DevOps (Build & Push Images)
+
+Hanya DevOps lead (@PangeranSilaen) yang build dan push images ke Docker Hub.
+
+```
+1. Pastikan PR backend/frontend sudah merged ke master
+2. Checkout master dan pull latest
+3. Build images:
+   .\scripts\temuin.ps1 build
+
+4. Push ke Docker Hub:
+   docker push pangeransilaen/temuin-backend:latest
+   docker push pangeransilaen/temuin-frontend:latest
+
+5. Tim bisa pull images terbaru
+```
+
+## Command Reference
+
+| Command          | Fungsi                                                                                                            |
+|------------------|-------------------------------------------------------------------------------------------------------------------|
+| `start`          | Buat `.env` jika belum ada, buat placeholder `serviceAccountKey.json` jika belum ada, start db → backend → frontend |
+| `stop`           | Stop semua container. Data **tetap tersimpan** di volume                                                          |
+| `restart`        | Stop + start                                                                                                      |
+| `status`         | Lihat status container dan URL akses                                                                              |
+| `logs [service]` | Tail logs (opsional: `db`, `backend`, `frontend`)                                                                 |
+| `build`          | Build images lokal (hanya untuk DevOps)                                                                           |
+| `pull`           | Pull images dari Docker Hub                                                                                       |
+| `migrate`        | Jalankan Alembic migrations (sudah otomatis saat backend start)                                                   |
+| `seed`           | Seed master data (categories, buildings) — hanya perlu sekali                                                     |
+
+## Catatan Penting
+
+- **Database TIDAK di-reset** saat start/stop. Data tersimpan di Docker volume `temuin_pgdata`. Untuk reset total: `docker volume rm temuin_pgdata` lalu start ulang.
+- **Migrations otomatis**: Backend container menjalankan `alembic upgrade head` saat start via `entrypoint.sh`. Command `migrate` hanya untuk manual run jika perlu.
+- **Seed data**: Jalankan `seed` sekali setelah pertama kali start. Ini mengisi tabel `categories` dan `buildings` dengan data awal.
+- **Frontend env berubah**: Jalankan `build` ulang karena `VITE_*` di-bake saat build.
+
+## Akses
+
+| Service  | URL                        |
+|----------|----------------------------|
+| Frontend | http://localhost:3000       |
+| Backend  | http://localhost:8000       |
+| API Docs | http://localhost:8000/docs  |
+| Database | localhost:5434 (postgres)   |
+
+## Docker Hub Images
+
+- `pangeransilaen/temuin-backend:latest`
+- `pangeransilaen/temuin-frontend:latest`
+
+## Troubleshooting
+
+- **Port conflict**: Edit `DB_PORT` di `.env` jika port 5434 sudah terpakai
+- **Firebase error**: Pastikan `serviceAccountKey.json` ada di `backend/`. Tanpa file ini, login tidak bisa tapi endpoint lain tetap jalan
+- **DB connection error**: Tunggu beberapa detik setelah start, PostgreSQL butuh waktu init
+- **Frontend env berubah**: Jalankan `build` ulang karena `VITE_*` di-bake saat build
+- **Mau reset database**: `docker volume rm temuin_pgdata` lalu `.\scripts\temuin.ps1 start` ulang

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,29 @@
+# Dependencies (will be installed fresh in container)
+node_modules/
+
+# Build output (will be built in container)
+dist/
+
+# Environment files
+.env
+.env.local
+.env.production
+
+# IDE
+.vscode/
+.idea/
+
+# Git
+.git/
+.gitignore
+
+# Docker
+Dockerfile
+.dockerignore
+
+# Documentation
+*.md
+
+# OS artifacts
+.DS_Store
+Thumbs.db

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,55 @@
+# ============================================================
+# Multi-Stage Build: Temuin Frontend (React + Vite + Nginx)
+# ============================================================
+# Stage 1: Build - npm ci + vite build
+# Stage 2: Serve - nginx:alpine serves static files
+# ============================================================
+
+# ============================================================
+# Stage 1: Build
+# ============================================================
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+# Build arguments for Vite env vars (baked at build time)
+ARG VITE_API_BASE_URL=http://localhost:8000
+ARG VITE_FIREBASE_API_KEY
+ARG VITE_FIREBASE_AUTH_DOMAIN
+ARG VITE_FIREBASE_PROJECT_ID
+ARG VITE_FIREBASE_STORAGE_BUCKET
+ARG VITE_FIREBASE_MESSAGING_SENDER_ID
+ARG VITE_FIREBASE_APP_ID
+
+# Copy package files first (cache optimization)
+COPY package.json package-lock.json ./
+
+# Install dependencies
+RUN npm ci --ignore-scripts
+
+# Copy source code
+COPY . .
+
+# Build the app (VITE_* args are available as env vars during build)
+RUN npm run build
+
+# ============================================================
+# Stage 2: Serve with Nginx
+# ============================================================
+FROM nginx:alpine
+
+# Remove default nginx config
+RUN rm /etc/nginx/conf.d/default.conf
+
+# Copy custom nginx config
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Copy built files from build stage
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget -qO- http://localhost:80/ > /dev/null 2>&1 || exit 1
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -25,7 +25,7 @@ ARG VITE_FIREBASE_APP_ID
 COPY package.json package-lock.json ./
 
 # Install dependencies
-RUN npm ci --ignore-scripts
+RUN npm ci
 
 # Copy source code
 COPY . .

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,40 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA routing: all routes fallback to index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets aggressively
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        access_log off;
+    }
+
+    # Proxy API requests to backend container
+    # Frontend can use /api/* instead of direct backend URL
+    location /api/ {
+        proxy_pass http://temuin-backend:8000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    # Gzip compression
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript image/svg+xml;
+}

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -20,7 +20,7 @@ server {
     # Proxy API requests to backend container
     # Frontend can use /api/* instead of direct backend URL
     location /api/ {
-        proxy_pass http://temuin-backend:8000/;
+        proxy_pass http://backend:8000/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/scripts/temuin.ps1
+++ b/scripts/temuin.ps1
@@ -1,0 +1,210 @@
+# ============================================================
+# Temuin - Docker Runner Script (PowerShell)
+# ============================================================
+# Usage: .\scripts\temuin.ps1 [command]
+# Commands: start, stop, restart, status, logs, build, pull,
+#           migrate, seed, help
+# ============================================================
+
+param(
+    [Parameter(Position = 0)]
+    [string]$Command = "help",
+
+    [Parameter(Position = 1)]
+    [string]$Service = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+# Navigate to project root (where docker-compose.yml lives)
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Split-Path -Parent $ScriptDir
+Set-Location $ProjectRoot
+
+# ============================================================
+# Helpers
+# ============================================================
+
+function Write-Color {
+    param([string]$Text, [string]$Color = "White")
+    Write-Host $Text -ForegroundColor $Color
+}
+
+function Test-Docker {
+    if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+        Write-Color "Error: Docker is not installed or not in PATH" "Red"
+        exit 1
+    }
+    $composeCheck = docker compose version 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Color "Error: Docker Compose V2 is not available" "Red"
+        exit 1
+    }
+}
+
+function Test-EnvFile {
+    if (-not (Test-Path ".env")) {
+        Write-Color "Warning: .env file not found." "Yellow"
+        Write-Host "Copying from .env.docker template..."
+        Copy-Item ".env.docker" ".env"
+        Write-Color ".env created from .env.docker" "Green"
+        Write-Color "Please edit .env with your actual values (especially Firebase config)." "Yellow"
+    }
+}
+
+# ============================================================
+# Commands
+# ============================================================
+
+function Invoke-Start {
+    Write-Color "=== Starting Temuin ===" "Cyan"
+    Test-Docker
+    Test-EnvFile
+    docker compose up -d
+    Write-Host ""
+    Invoke-Status
+}
+
+function Invoke-Stop {
+    Write-Color "=== Stopping Temuin ===" "Cyan"
+    Test-Docker
+    docker compose down
+    Write-Color "All containers stopped." "Green"
+}
+
+function Invoke-Restart {
+    Write-Color "=== Restarting Temuin ===" "Cyan"
+    Invoke-Stop
+    Write-Host ""
+    Invoke-Start
+}
+
+function Invoke-Status {
+    Test-Docker
+    Write-Color "=== Container Status ===" "Cyan"
+    docker compose ps
+    Write-Host ""
+    Write-Color "=== Access URLs ===" "Cyan"
+    Write-Host "  Frontend:  " -NoNewline; Write-Color "http://localhost:3000" "Green"
+    Write-Host "  Backend:   " -NoNewline; Write-Color "http://localhost:8000" "Green"
+    Write-Host "  API Docs:  " -NoNewline; Write-Color "http://localhost:8000/docs" "Green"
+    Write-Host "  Database:  " -NoNewline; Write-Color "localhost:5434 (user: postgres)" "Green"
+}
+
+function Invoke-Logs {
+    Test-Docker
+    if ($Service -eq "") {
+        docker compose logs -f --tail=100
+    }
+    else {
+        docker compose logs -f --tail=100 $Service
+    }
+}
+
+function Invoke-Build {
+    Write-Color "=== Building Temuin Images ===" "Cyan"
+    Test-Docker
+    Test-EnvFile
+    docker compose build
+    Write-Color "Build complete." "Green"
+}
+
+function Invoke-Pull {
+    Write-Color "=== Pulling Temuin Images from Docker Hub ===" "Cyan"
+    Test-Docker
+    docker compose pull backend frontend
+    Write-Color "Pull complete." "Green"
+}
+
+function Invoke-Migrate {
+    Write-Color "=== Running Alembic Migrations ===" "Cyan"
+    Test-Docker
+    docker compose exec backend alembic upgrade head
+    Write-Color "Migrations complete." "Green"
+}
+
+function Invoke-Seed {
+    Write-Color "=== Seeding Database ===" "Cyan"
+    Test-Docker
+
+    $dbRunning = docker compose ps db 2>&1 | Select-String "running"
+    if (-not $dbRunning) {
+        Write-Color "Error: Database container is not running. Run '.\scripts\temuin.ps1 start' first." "Red"
+        exit 1
+    }
+
+    Write-Host "Creating seed data..."
+    $seedSQL = @"
+        INSERT INTO categories (name, description) VALUES
+            ('Elektronik', 'Perangkat elektronik seperti laptop, HP, charger'),
+            ('Dokumen', 'KTM, KTP, SIM, dan dokumen penting lainnya'),
+            ('Aksesoris', 'Jam tangan, kacamata, perhiasan'),
+            ('Pakaian', 'Jaket, topi, sepatu, dan pakaian lainnya'),
+            ('Lainnya', 'Barang lain yang tidak masuk kategori di atas')
+        ON CONFLICT DO NOTHING;
+
+        INSERT INTO buildings (name, code) VALUES
+            ('Gedung Kuliah Bersama', 'GKB'),
+            ('Gedung Rektorat', 'REK'),
+            ('Perpustakaan', 'LIB'),
+            ('Gedung Teknik Informatika', 'IF'),
+            ('Kantin Pusat', 'KAN')
+        ON CONFLICT DO NOTHING;
+"@
+
+    docker compose exec db psql -U postgres -d temuin_db -c $seedSQL 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Color "Note: Some seed data may already exist or tables not yet created." "Yellow"
+    }
+
+    Write-Color "Seed complete." "Green"
+}
+
+function Invoke-Help {
+    Write-Color "============================================================" "Cyan"
+    Write-Color "  Temuin - Docker Runner" "Cyan"
+    Write-Color "============================================================" "Cyan"
+    Write-Host ""
+    Write-Host "Usage: " -NoNewline; Write-Color ".\scripts\temuin.ps1" "Green" -NoNewline; Write-Color " [command]" "Yellow"
+    Write-Host ""
+    Write-Host "Commands:"
+    Write-Host "  " -NoNewline; Write-Color "start" "Green" -NoNewline; Write-Host "              Start all containers"
+    Write-Host "  " -NoNewline; Write-Color "stop" "Green" -NoNewline; Write-Host "               Stop all containers"
+    Write-Host "  " -NoNewline; Write-Color "restart" "Green" -NoNewline; Write-Host "            Restart all containers"
+    Write-Host "  " -NoNewline; Write-Color "status" "Green" -NoNewline; Write-Host "             Show container status and URLs"
+    Write-Host "  " -NoNewline; Write-Color "logs" "Green" -NoNewline; Write-Host " [service]     Tail logs (optional: db, backend, frontend)"
+    Write-Host "  " -NoNewline; Write-Color "build" "Green" -NoNewline; Write-Host "              Build images locally"
+    Write-Host "  " -NoNewline; Write-Color "pull" "Green" -NoNewline; Write-Host "               Pull images from Docker Hub"
+    Write-Host "  " -NoNewline; Write-Color "migrate" "Green" -NoNewline; Write-Host "            Run Alembic database migrations"
+    Write-Host "  " -NoNewline; Write-Color "seed" "Green" -NoNewline; Write-Host "               Seed database with initial data"
+    Write-Host "  " -NoNewline; Write-Color "help" "Green" -NoNewline; Write-Host "               Show this help message"
+    Write-Host ""
+    Write-Host "Examples:"
+    Write-Host "  .\scripts\temuin.ps1 start          # Start everything"
+    Write-Host "  .\scripts\temuin.ps1 logs backend    # Tail backend logs"
+    Write-Host "  .\scripts\temuin.ps1 seed            # Seed the database"
+    Write-Host ""
+}
+
+# ============================================================
+# Main
+# ============================================================
+
+switch ($Command.ToLower()) {
+    "start"   { Invoke-Start }
+    "stop"    { Invoke-Stop }
+    "restart" { Invoke-Restart }
+    "status"  { Invoke-Status }
+    "logs"    { Invoke-Logs }
+    "build"   { Invoke-Build }
+    "pull"    { Invoke-Pull }
+    "migrate" { Invoke-Migrate }
+    "seed"    { Invoke-Seed }
+    "help"    { Invoke-Help }
+    default {
+        Write-Color "Unknown command: $Command" "Red"
+        Write-Host ""
+        Invoke-Help
+        exit 1
+    }
+}

--- a/scripts/temuin.ps1
+++ b/scripts/temuin.ps1
@@ -150,20 +150,20 @@ function Invoke-Seed {
 
     Write-Host "Creating seed data..."
     $seedSQL = @"
-        INSERT INTO categories (name, description) VALUES
-            ('Elektronik', 'Perangkat elektronik seperti laptop, HP, charger'),
-            ('Dokumen', 'KTM, KTP, SIM, dan dokumen penting lainnya'),
-            ('Aksesoris', 'Jam tangan, kacamata, perhiasan'),
-            ('Pakaian', 'Jaket, topi, sepatu, dan pakaian lainnya'),
-            ('Lainnya', 'Barang lain yang tidak masuk kategori di atas')
+        INSERT INTO categories (id, name) VALUES
+            ('cat-elektronik', 'Elektronik'),
+            ('cat-dokumen', 'Dokumen'),
+            ('cat-aksesoris', 'Aksesoris'),
+            ('cat-pakaian', 'Pakaian'),
+            ('cat-lainnya', 'Lainnya')
         ON CONFLICT DO NOTHING;
 
-        INSERT INTO buildings (name, code) VALUES
-            ('Gedung Kuliah Bersama', 'GKB'),
-            ('Gedung Rektorat', 'REK'),
-            ('Perpustakaan', 'LIB'),
-            ('Gedung Teknik Informatika', 'IF'),
-            ('Kantin Pusat', 'KAN')
+        INSERT INTO buildings (id, name) VALUES
+            ('bld-gkb', 'Gedung Kuliah Bersama'),
+            ('bld-rek', 'Gedung Rektorat'),
+            ('bld-lib', 'Perpustakaan'),
+            ('bld-if', 'Gedung Teknik Informatika'),
+            ('bld-kan', 'Kantin Pusat')
         ON CONFLICT DO NOTHING;
 "@
 

--- a/scripts/temuin.ps1
+++ b/scripts/temuin.ps1
@@ -26,8 +26,14 @@ Set-Location $ProjectRoot
 # ============================================================
 
 function Write-Color {
-    param([string]$Text, [string]$Color = "White")
-    Write-Host $Text -ForegroundColor $Color
+    param(
+        [string]$Text,
+        [string]$Color = "White",
+        [switch]$NoNewline
+    )
+    $params = @{ Object = $Text; ForegroundColor = $Color }
+    if ($NoNewline) { $params.NoNewline = $true }
+    Write-Host @params
 }
 
 function Test-Docker {
@@ -56,10 +62,19 @@ function Test-EnvFile {
 # Commands
 # ============================================================
 
+function Test-FirebaseCreds {
+    if (-not (Test-Path "backend/serviceAccountKey.json")) {
+        Write-Color "WARNING: backend/serviceAccountKey.json not found." "Yellow"
+        Write-Host "Creating empty placeholder. Firebase auth will NOT work until you add the real file."
+        '{}' | Set-Content "backend/serviceAccountKey.json" -Encoding UTF8
+    }
+}
+
 function Invoke-Start {
     Write-Color "=== Starting Temuin ===" "Cyan"
     Test-Docker
     Test-EnvFile
+    Test-FirebaseCreds
     docker compose up -d
     Write-Host ""
     Invoke-Status

--- a/scripts/temuin.sh
+++ b/scripts/temuin.sh
@@ -138,22 +138,22 @@ cmd_seed() {
 
     echo "Creating seed data..."
     docker compose exec db psql -U postgres -d temuin_db -c "
-        -- Insert default categories
-        INSERT INTO categories (name, description) VALUES
-            ('Elektronik', 'Perangkat elektronik seperti laptop, HP, charger'),
-            ('Dokumen', 'KTM, KTP, SIM, dan dokumen penting lainnya'),
-            ('Aksesoris', 'Jam tangan, kacamata, perhiasan'),
-            ('Pakaian', 'Jaket, topi, sepatu, dan pakaian lainnya'),
-            ('Lainnya', 'Barang lain yang tidak masuk kategori di atas')
+        -- Insert default categories (model: id String PK, name String)
+        INSERT INTO categories (id, name) VALUES
+            ('cat-elektronik', 'Elektronik'),
+            ('cat-dokumen', 'Dokumen'),
+            ('cat-aksesoris', 'Aksesoris'),
+            ('cat-pakaian', 'Pakaian'),
+            ('cat-lainnya', 'Lainnya')
         ON CONFLICT DO NOTHING;
 
-        -- Insert default buildings
-        INSERT INTO buildings (name, code) VALUES
-            ('Gedung Kuliah Bersama', 'GKB'),
-            ('Gedung Rektorat', 'REK'),
-            ('Perpustakaan', 'LIB'),
-            ('Gedung Teknik Informatika', 'IF'),
-            ('Kantin Pusat', 'KAN')
+        -- Insert default buildings (model: id String PK, name String)
+        INSERT INTO buildings (id, name) VALUES
+            ('bld-gkb', 'Gedung Kuliah Bersama'),
+            ('bld-rek', 'Gedung Rektorat'),
+            ('bld-lib', 'Perpustakaan'),
+            ('bld-if', 'Gedung Teknik Informatika'),
+            ('bld-kan', 'Kantin Pusat')
         ON CONFLICT DO NOTHING;
     " 2>/dev/null || echo -e "${YELLOW}Note: Some seed data may already exist or tables not yet created.${NC}"
 

--- a/scripts/temuin.sh
+++ b/scripts/temuin.sh
@@ -45,6 +45,15 @@ check_env() {
     fi
 }
 
+# Check Firebase credentials exist
+check_firebase() {
+    if [ ! -f "backend/serviceAccountKey.json" ]; then
+        echo -e "${YELLOW}WARNING: backend/serviceAccountKey.json not found.${NC}"
+        echo "Creating empty placeholder. Firebase auth will NOT work until you add the real file."
+        echo '{}' > backend/serviceAccountKey.json
+    fi
+}
+
 # ============================================================
 # Commands
 # ============================================================
@@ -53,6 +62,7 @@ cmd_start() {
     echo -e "${CYAN}=== Starting Temuin ===${NC}"
     check_docker
     check_env
+    check_firebase
     docker compose up -d
     echo ""
     cmd_status

--- a/scripts/temuin.sh
+++ b/scripts/temuin.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+# ============================================================
+# Temuin - Docker Runner Script (Bash)
+# ============================================================
+# Usage: ./scripts/temuin.sh [command]
+# Commands: start, stop, restart, status, logs, build, pull,
+#           migrate, seed, help
+# ============================================================
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# Navigate to project root (where docker-compose.yml lives)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+# Check docker compose is available
+check_docker() {
+    if ! command -v docker &> /dev/null; then
+        echo -e "${RED}Error: Docker is not installed or not in PATH${NC}"
+        exit 1
+    fi
+    if ! docker compose version &> /dev/null; then
+        echo -e "${RED}Error: Docker Compose V2 is not available${NC}"
+        exit 1
+    fi
+}
+
+# Check .env file exists
+check_env() {
+    if [ ! -f ".env" ]; then
+        echo -e "${YELLOW}Warning: .env file not found.${NC}"
+        echo -e "Copying from .env.docker template..."
+        cp .env.docker .env
+        echo -e "${GREEN}.env created from .env.docker${NC}"
+        echo -e "${YELLOW}Please edit .env with your actual values (especially Firebase config).${NC}"
+    fi
+}
+
+# ============================================================
+# Commands
+# ============================================================
+
+cmd_start() {
+    echo -e "${CYAN}=== Starting Temuin ===${NC}"
+    check_docker
+    check_env
+    docker compose up -d
+    echo ""
+    cmd_status
+}
+
+cmd_stop() {
+    echo -e "${CYAN}=== Stopping Temuin ===${NC}"
+    check_docker
+    docker compose down
+    echo -e "${GREEN}All containers stopped.${NC}"
+}
+
+cmd_restart() {
+    echo -e "${CYAN}=== Restarting Temuin ===${NC}"
+    cmd_stop
+    echo ""
+    cmd_start
+}
+
+cmd_status() {
+    check_docker
+    echo -e "${CYAN}=== Container Status ===${NC}"
+    docker compose ps
+    echo ""
+    echo -e "${CYAN}=== Access URLs ===${NC}"
+    echo -e "  Frontend:  ${GREEN}http://localhost:3000${NC}"
+    echo -e "  Backend:   ${GREEN}http://localhost:8000${NC}"
+    echo -e "  API Docs:  ${GREEN}http://localhost:8000/docs${NC}"
+    echo -e "  Database:  ${GREEN}localhost:5434${NC} (user: postgres)"
+}
+
+cmd_logs() {
+    check_docker
+    SERVICE=${1:-""}
+    if [ -z "$SERVICE" ]; then
+        docker compose logs -f --tail=100
+    else
+        docker compose logs -f --tail=100 "$SERVICE"
+    fi
+}
+
+cmd_build() {
+    echo -e "${CYAN}=== Building Temuin Images ===${NC}"
+    check_docker
+    check_env
+    docker compose build
+    echo -e "${GREEN}Build complete.${NC}"
+}
+
+cmd_pull() {
+    echo -e "${CYAN}=== Pulling Temuin Images from Docker Hub ===${NC}"
+    check_docker
+    docker compose pull backend frontend
+    echo -e "${GREEN}Pull complete.${NC}"
+}
+
+cmd_migrate() {
+    echo -e "${CYAN}=== Running Alembic Migrations ===${NC}"
+    check_docker
+    docker compose exec backend alembic upgrade head
+    echo -e "${GREEN}Migrations complete.${NC}"
+}
+
+cmd_seed() {
+    echo -e "${CYAN}=== Seeding Database ===${NC}"
+    check_docker
+
+    # Check if db container is running
+    if ! docker compose ps db | grep -q "running"; then
+        echo -e "${RED}Error: Database container is not running. Run './scripts/temuin.sh start' first.${NC}"
+        exit 1
+    fi
+
+    echo "Creating seed data..."
+    docker compose exec db psql -U postgres -d temuin_db -c "
+        -- Insert default categories
+        INSERT INTO categories (name, description) VALUES
+            ('Elektronik', 'Perangkat elektronik seperti laptop, HP, charger'),
+            ('Dokumen', 'KTM, KTP, SIM, dan dokumen penting lainnya'),
+            ('Aksesoris', 'Jam tangan, kacamata, perhiasan'),
+            ('Pakaian', 'Jaket, topi, sepatu, dan pakaian lainnya'),
+            ('Lainnya', 'Barang lain yang tidak masuk kategori di atas')
+        ON CONFLICT DO NOTHING;
+
+        -- Insert default buildings
+        INSERT INTO buildings (name, code) VALUES
+            ('Gedung Kuliah Bersama', 'GKB'),
+            ('Gedung Rektorat', 'REK'),
+            ('Perpustakaan', 'LIB'),
+            ('Gedung Teknik Informatika', 'IF'),
+            ('Kantin Pusat', 'KAN')
+        ON CONFLICT DO NOTHING;
+    " 2>/dev/null || echo -e "${YELLOW}Note: Some seed data may already exist or tables not yet created.${NC}"
+
+    echo -e "${GREEN}Seed complete.${NC}"
+}
+
+cmd_help() {
+    echo -e "${CYAN}============================================================${NC}"
+    echo -e "${CYAN}  Temuin - Docker Runner${NC}"
+    echo -e "${CYAN}============================================================${NC}"
+    echo ""
+    echo -e "Usage: ${GREEN}./scripts/temuin.sh${NC} ${YELLOW}[command]${NC}"
+    echo ""
+    echo -e "Commands:"
+    echo -e "  ${GREEN}start${NC}              Start all containers"
+    echo -e "  ${GREEN}stop${NC}               Stop all containers"
+    echo -e "  ${GREEN}restart${NC}            Restart all containers"
+    echo -e "  ${GREEN}status${NC}             Show container status and URLs"
+    echo -e "  ${GREEN}logs${NC} [service]     Tail logs (optional: db, backend, frontend)"
+    echo -e "  ${GREEN}build${NC}              Build images locally"
+    echo -e "  ${GREEN}pull${NC}               Pull images from Docker Hub"
+    echo -e "  ${GREEN}migrate${NC}            Run Alembic database migrations"
+    echo -e "  ${GREEN}seed${NC}               Seed database with initial data"
+    echo -e "  ${GREEN}help${NC}               Show this help message"
+    echo ""
+    echo -e "Examples:"
+    echo -e "  ./scripts/temuin.sh start          # Start everything"
+    echo -e "  ./scripts/temuin.sh logs backend    # Tail backend logs"
+    echo -e "  ./scripts/temuin.sh seed            # Seed the database"
+    echo ""
+}
+
+# ============================================================
+# Main
+# ============================================================
+
+COMMAND=${1:-help}
+
+case "$COMMAND" in
+    start)    cmd_start ;;
+    stop)     cmd_stop ;;
+    restart)  cmd_restart ;;
+    status)   cmd_status ;;
+    logs)     cmd_logs "$2" ;;
+    build)    cmd_build ;;
+    pull)     cmd_pull ;;
+    migrate)  cmd_migrate ;;
+    seed)     cmd_seed ;;
+    help)     cmd_help ;;
+    *)
+        echo -e "${RED}Unknown command: $COMMAND${NC}"
+        echo ""
+        cmd_help
+        exit 1
+        ;;
+esac

--- a/temuin-docs/05-roles/devops.md
+++ b/temuin-docs/05-roles/devops.md
@@ -22,72 +22,9 @@
 3. Jangan buat workflow yang bergantung pada permission admin repo kalau belum pasti ada
 4. Dokumentasikan langkah penting seperlunya
 
-## Docker Compose Quick Guide (Sprint 3)
+## Docker
 
-### Prerequisites
-
-- Docker Desktop (terbaru) sudah terinstall dan running
-
-### Setup (Sekali Saja)
-
-1. Copy environment template:
-   ```bash
-   cp .env.docker .env          # Linux/Mac
-   copy .env.docker .env        # Windows
-   ```
-2. Edit `.env` -- isi Firebase config dari Firebase Console
-3. Taruh `serviceAccountKey.json` di folder `backend/` (file ini sudah di-`.gitignore`)
-
-### Menjalankan
-
-```bash
-# Linux/Mac
-./scripts/temuin.sh start
-
-# Windows PowerShell
-.\scripts\temuin.ps1 start
-```
-
-### Akses
-
-| Service   | URL                        |
-|-----------|----------------------------|
-| Frontend  | http://localhost:3000       |
-| Backend   | http://localhost:8000       |
-| API Docs  | http://localhost:8000/docs  |
-| Database  | localhost:5434 (postgres)   |
-
-### Command Lainnya
-
-| Command                  | Fungsi                          |
-|--------------------------|---------------------------------|
-| `start`                  | Start semua container           |
-| `stop`                   | Stop semua container            |
-| `restart`                | Restart semua container         |
-| `status`                 | Lihat status dan URL            |
-| `logs [service]`         | Tail logs (db/backend/frontend) |
-| `build`                  | Build images lokal              |
-| `pull`                   | Pull images dari Docker Hub     |
-| `migrate`                | Jalankan Alembic migrations     |
-| `seed`                   | Seed database dengan data awal  |
-
-### Troubleshooting
-
-- **Port conflict**: Edit `DB_PORT` di `.env` jika port 5434 sudah terpakai
-- **Firebase error**: Pastikan `serviceAccountKey.json` ada di `backend/`. Tanpa file ini, login tidak bisa tapi endpoint lain tetap jalan
-- **DB connection error**: Tunggu beberapa detik setelah start, PostgreSQL butuh waktu init
-- **Frontend env berubah**: Jalankan `build` ulang karena VITE_* di-bake saat build
-
-### Docker Hub Images
-
-- `pangeransilaen/temuin-backend:latest`
-- `pangeransilaen/temuin-frontend:latest`
-
-Tim bisa pull langsung tanpa build lokal:
-```bash
-./scripts/temuin.sh pull    # Pull images
-./scripts/temuin.sh start   # Start containers
-```
+Lihat panduan lengkap di [`docs/docker-guide.md`](../../docs/docker-guide.md).
 
 ## Bacaan Kunci
 

--- a/temuin-docs/05-roles/devops.md
+++ b/temuin-docs/05-roles/devops.md
@@ -22,6 +22,73 @@
 3. Jangan buat workflow yang bergantung pada permission admin repo kalau belum pasti ada
 4. Dokumentasikan langkah penting seperlunya
 
+## Docker Compose Quick Guide (Sprint 3)
+
+### Prerequisites
+
+- Docker Desktop (terbaru) sudah terinstall dan running
+
+### Setup (Sekali Saja)
+
+1. Copy environment template:
+   ```bash
+   cp .env.docker .env          # Linux/Mac
+   copy .env.docker .env        # Windows
+   ```
+2. Edit `.env` -- isi Firebase config dari Firebase Console
+3. Taruh `serviceAccountKey.json` di folder `backend/` (file ini sudah di-`.gitignore`)
+
+### Menjalankan
+
+```bash
+# Linux/Mac
+./scripts/temuin.sh start
+
+# Windows PowerShell
+.\scripts\temuin.ps1 start
+```
+
+### Akses
+
+| Service   | URL                        |
+|-----------|----------------------------|
+| Frontend  | http://localhost:3000       |
+| Backend   | http://localhost:8000       |
+| API Docs  | http://localhost:8000/docs  |
+| Database  | localhost:5434 (postgres)   |
+
+### Command Lainnya
+
+| Command                  | Fungsi                          |
+|--------------------------|---------------------------------|
+| `start`                  | Start semua container           |
+| `stop`                   | Stop semua container            |
+| `restart`                | Restart semua container         |
+| `status`                 | Lihat status dan URL            |
+| `logs [service]`         | Tail logs (db/backend/frontend) |
+| `build`                  | Build images lokal              |
+| `pull`                   | Pull images dari Docker Hub     |
+| `migrate`                | Jalankan Alembic migrations     |
+| `seed`                   | Seed database dengan data awal  |
+
+### Troubleshooting
+
+- **Port conflict**: Edit `DB_PORT` di `.env` jika port 5434 sudah terpakai
+- **Firebase error**: Pastikan `serviceAccountKey.json` ada di `backend/`. Tanpa file ini, login tidak bisa tapi endpoint lain tetap jalan
+- **DB connection error**: Tunggu beberapa detik setelah start, PostgreSQL butuh waktu init
+- **Frontend env berubah**: Jalankan `build` ulang karena VITE_* di-bake saat build
+
+### Docker Hub Images
+
+- `pangeransilaen/temuin-backend:latest`
+- `pangeransilaen/temuin-frontend:latest`
+
+Tim bisa pull langsung tanpa build lokal:
+```bash
+./scripts/temuin.sh pull    # Pull images
+./scripts/temuin.sh start   # Start containers
+```
+
 ## Bacaan Kunci
 
 - `temuin-docs/03-architecture/devops-architecture.md`

--- a/temuin-docs/06-sprints/sprint-03.md
+++ b/temuin-docs/06-sprints/sprint-03.md
@@ -26,10 +26,10 @@ Menyelesaikan search, filter, claim flow, notifications, dan master data.
 
 | ID | Task | Priority | Estimate | Depends On | Status | Branch/Ref | Notes |
 |----|------|----------|----------|------------|--------|------------|-------|
-| DO-3.1 | Buat Dockerfile backend | High | 2h | BE-2.4 | todo | - | - |
-| DO-3.2 | Buat Dockerfile frontend | High | 2h | FE-2.4 | todo | - | - |
-| DO-3.3 | Buat `docker-compose.yml` monolith | High | 3h | DO-3.1, DO-3.2 | todo | - | - |
-| DO-3.4 | Tulis panduan singkat menjalankan Docker Compose | Medium | 1h | DO-3.3 | todo | - | - |
+| DO-3.1 | Buat Dockerfile backend | High | 2h | BE-2.4 | in_progress | feat/devops/sprint-03-docker | Multi-stage Alpine, entrypoint.sh with Alembic |
+| DO-3.2 | Buat Dockerfile frontend | High | 2h | FE-2.4 | in_progress | feat/devops/sprint-03-docker | Node build + Nginx serve, SPA routing |
+| DO-3.3 | Buat `docker-compose.yml` monolith | High | 3h | DO-3.1, DO-3.2 | in_progress | feat/devops/sprint-03-docker | + runner scripts (sh/ps1), .env.docker |
+| DO-3.4 | Tulis panduan singkat menjalankan Docker Compose | Medium | 1h | DO-3.3 | in_progress | feat/devops/sprint-03-docker | Added to devops.md |
 
 ## Lead QA & Docs (@raniayudewi)
 


### PR DESCRIPTION
## Summary

Docker containerization untuk Temuin monolith (Sprint 03 DevOps tasks).

- **DO-3.1**: Dockerfile backend (multi-stage Alpine, entrypoint dengan Alembic migrations)
- **DO-3.2**: Dockerfile frontend (Node build + Nginx serve, SPA routing)
- **DO-3.3**: docker-compose.yml + runner scripts (Bash + PowerShell)
- **DO-3.4**: Panduan singkat di devops.md

## Docker Hub Images

- `pangeransilaen/temuin-backend:latest`
- `pangeransilaen/temuin-frontend:latest`

## Quick Start

```bash
# Salin template environment
cp .env.docker .env
# Edit .env, isi config Firebase dari Firebase Console

# Jalankan semua
./scripts/temuin.sh start     # Linux/Mac
.\scripts\temuin.ps1 start    # Windows
```

## Access URLs

| Service | URL |
|---------|-----|
| Frontend | http://localhost:3000 |
| Backend | http://localhost:8000 |
| API Docs | http://localhost:8000/docs |
| Database | localhost:5434 |

## Verified

- [x] Image backend berhasil di-build
- [x] Image frontend berhasil di-build
- [x] `docker compose up` menjalankan 3 container
- [x] Health check backend lolos (DB connected)
- [x] Frontend melayani SPA dengan benar (try_files jalan)
- [x] Image sudah di-push ke Docker Hub
- [x] Clean test: hapus semua image lokal, pull dari Docker Hub, jalankan script -- semua berjalan

## Notes

- Migrasi Alembic punya masalah urutan yang sudah ada sebelumnya (migrasi ke-3 mereferensikan tabel `users` sebelum tabel itu dibuat). entrypoint.sh menangani ini dengan baik -- memberi peringatan lalu tetap menjalankan app. Ini masalah kode backend, bukan masalah Docker.
- Port 5434 untuk PostgreSQL agar tidak bentrok dengan praktikum (5433) dan lokal (5432)
- Firebase credentials di-mount via volume (tidak pernah di-bake ke dalam image)
- Jika `serviceAccountKey.json` belum ada, script otomatis membuat placeholder kosong dan memberi peringatan
