### PR TITLE
fix(devops): fix Docker auth, Dockerfile ARG/ENV, healthcheck, clock skew

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -64,7 +64,7 @@ USER appuser
 
 EXPOSE 8000
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=3)"
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/backend/app/auth/firebase.py
+++ b/backend/app/auth/firebase.py
@@ -4,6 +4,12 @@ from fastapi import HTTPException, status
 
 logger = logging.getLogger(__name__)
 
+# Toleransi clock skew antara Docker container dan Google server.
+# Docker Desktop di Windows/Mac sering mengalami clock drift setelah
+# sleep/hibernate, menyebabkan error "Token used too early".
+# Nilai maksimum yang diizinkan Firebase SDK: 60 detik.
+CLOCK_SKEW_SECONDS = 5
+
 def verify_firebase_token(id_token: str) -> dict:
     """
     Verifies a Firebase ID token using the Firebase Admin SDK.
@@ -11,7 +17,7 @@ def verify_firebase_token(id_token: str) -> dict:
     Raises HTTPException if invalid.
     """
     try:
-        decoded_token = auth.verify_id_token(id_token)
+        decoded_token = auth.verify_id_token(id_token, clock_skew_seconds=CLOCK_SKEW_SECONDS)
         return decoded_token
     except auth.ExpiredIdTokenError:
         logger.warning("Firebase token expired.")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Depends
+from fastapi import FastAPI, Depends, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 from sqlalchemy import text
@@ -58,4 +58,7 @@ def health_check(db: Session = Depends(get_db)):
         db.execute(text("SELECT 1"))
         return {"status": "healthy", "database": "connected"}
     except Exception as e:
-        return {"status": "unhealthy", "database": str(e)}
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={"status": "unhealthy", "database": str(e)}
+        )

--- a/docs/docker-guide.md
+++ b/docs/docker-guide.md
@@ -78,6 +78,7 @@ Hanya DevOps lead (@PangeranSilaen) yang build dan push images ke Docker Hub.
 | `start`          | Buat `.env` jika belum ada, buat placeholder `serviceAccountKey.json` jika belum ada, start db → backend → frontend |
 | `stop`           | Stop semua container. Data **tetap tersimpan** di volume                                                          |
 | `restart`        | Stop + start                                                                                                      |
+| `reset`          | Full clean restart: stop, hapus volume DB, pull images terbaru, start ulang. **MENGHAPUS semua data!**            |
 | `status`         | Lihat status container dan URL akses                                                                              |
 | `logs [service]` | Tail logs (opsional: `db`, `backend`, `frontend`)                                                                 |
 | `build`          | Build images lokal (hanya untuk DevOps)                                                                           |
@@ -87,7 +88,7 @@ Hanya DevOps lead (@PangeranSilaen) yang build dan push images ke Docker Hub.
 
 ## Catatan Penting
 
-- **Database TIDAK di-reset** saat start/stop. Data tersimpan di Docker volume `temuin_pgdata`. Untuk reset total: `docker volume rm temuin_pgdata` lalu start ulang.
+- **Database TIDAK di-reset** saat start/stop. Data tersimpan di Docker volume `temuin_pgdata`. Untuk reset total: jalankan `reset` command (atau manual: `docker compose down -v` lalu start ulang).
 - **Migrations otomatis**: Backend container menjalankan `alembic upgrade head` saat start via `entrypoint.sh`. Command `migrate` hanya untuk manual run jika perlu.
 - **Seed data**: Jalankan `seed` sekali setelah pertama kali start. Ini mengisi tabel `categories` dan `buildings` dengan data awal.
 - **Frontend env berubah**: Jalankan `build` ulang karena `VITE_*` di-bake saat build.
@@ -112,4 +113,4 @@ Hanya DevOps lead (@PangeranSilaen) yang build dan push images ke Docker Hub.
 - **Firebase error**: Pastikan `serviceAccountKey.json` ada di `backend/`. Tanpa file ini, login tidak bisa tapi endpoint lain tetap jalan
 - **DB connection error**: Tunggu beberapa detik setelah start, PostgreSQL butuh waktu init
 - **Frontend env berubah**: Jalankan `build` ulang karena `VITE_*` di-bake saat build
-- **Mau reset database**: `docker volume rm temuin_pgdata` lalu `.\scripts\temuin.ps1 start` ulang
+- **Mau reset database**: Jalankan `.\scripts\temuin.ps1 reset` (akan hapus DB, pull images terbaru, dan start ulang)

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -21,6 +21,15 @@ ARG VITE_FIREBASE_STORAGE_BUCKET
 ARG VITE_FIREBASE_MESSAGING_SENDER_ID
 ARG VITE_FIREBASE_APP_ID
 
+# Convert ARGs to ENVs so Vite can read them via process.env during build
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+ENV VITE_FIREBASE_API_KEY=$VITE_FIREBASE_API_KEY
+ENV VITE_FIREBASE_AUTH_DOMAIN=$VITE_FIREBASE_AUTH_DOMAIN
+ENV VITE_FIREBASE_PROJECT_ID=$VITE_FIREBASE_PROJECT_ID
+ENV VITE_FIREBASE_STORAGE_BUCKET=$VITE_FIREBASE_STORAGE_BUCKET
+ENV VITE_FIREBASE_MESSAGING_SENDER_ID=$VITE_FIREBASE_MESSAGING_SENDER_ID
+ENV VITE_FIREBASE_APP_ID=$VITE_FIREBASE_APP_ID
+
 # Copy package files first (cache optimization)
 COPY package.json package-lock.json ./
 
@@ -30,7 +39,7 @@ RUN npm ci
 # Copy source code
 COPY . .
 
-# Build the app (VITE_* args are available as env vars during build)
+# Build the app (VITE_* env vars are read by Vite during build)
 RUN npm run build
 
 # ============================================================

--- a/scripts/temuin.ps1
+++ b/scripts/temuin.ps1
@@ -2,8 +2,8 @@
 # Temuin - Docker Runner Script (PowerShell)
 # ============================================================
 # Usage: .\scripts\temuin.ps1 [command]
-# Commands: start, stop, restart, status, logs, build, pull,
-#           migrate, seed, help
+# Commands: start, stop, restart, reset, status, logs, build,
+#           pull, migrate, seed, help
 # ============================================================
 
 param(
@@ -67,6 +67,12 @@ function Test-FirebaseCreds {
         Write-Color "WARNING: backend/serviceAccountKey.json not found." "Yellow"
         Write-Host "Creating empty placeholder. Firebase auth will NOT work until you add the real file."
         '{}' | Set-Content "backend/serviceAccountKey.json" -Encoding UTF8
+    } else {
+        $content = (Get-Content "backend/serviceAccountKey.json" -Raw).Trim()
+        if ($content -eq '{}' -or $content.Length -lt 50) {
+            Write-Color "WARNING: backend/serviceAccountKey.json appears to be a placeholder." "Yellow"
+            Write-Color "Firebase auth will NOT work. Replace with the real credentials file." "Yellow"
+        }
     }
 }
 
@@ -92,6 +98,27 @@ function Invoke-Restart {
     Invoke-Stop
     Write-Host ""
     Invoke-Start
+}
+
+function Invoke-Reset {
+    Write-Color "=== Resetting Temuin (full clean restart) ===" "Red"
+    Write-Color "WARNING: This will DELETE the database and all data!" "Yellow"
+    $confirm = Read-Host "Type 'yes' to confirm"
+    if ($confirm -ne "yes") {
+        Write-Color "Reset cancelled." "Yellow"
+        return
+    }
+    Test-Docker
+    Test-EnvFile
+    Test-FirebaseCreds
+    Write-Host "Stopping containers and removing volumes..."
+    docker compose down -v
+    Write-Host "Pulling latest images..."
+    docker compose pull backend frontend
+    Write-Host "Starting from scratch..."
+    docker compose up -d
+    Write-Host ""
+    Invoke-Status
 }
 
 function Invoke-Status {
@@ -184,8 +211,9 @@ function Invoke-Help {
     Write-Host ""
     Write-Host "Commands:"
     Write-Host "  " -NoNewline; Write-Color "start" "Green" -NoNewline; Write-Host "              Start all containers"
-    Write-Host "  " -NoNewline; Write-Color "stop" "Green" -NoNewline; Write-Host "               Stop all containers"
+    Write-Host "  " -NoNewline; Write-Color "stop" "Green" -NoNewline; Write-Host "               Stop all containers (data preserved)"
     Write-Host "  " -NoNewline; Write-Color "restart" "Green" -NoNewline; Write-Host "            Restart all containers"
+    Write-Host "  " -NoNewline; Write-Color "reset" "Green" -NoNewline; Write-Host "              Full clean restart (DELETES database!)"
     Write-Host "  " -NoNewline; Write-Color "status" "Green" -NoNewline; Write-Host "             Show container status and URLs"
     Write-Host "  " -NoNewline; Write-Color "logs" "Green" -NoNewline; Write-Host " [service]     Tail logs (optional: db, backend, frontend)"
     Write-Host "  " -NoNewline; Write-Color "build" "Green" -NoNewline; Write-Host "              Build images locally"
@@ -198,6 +226,7 @@ function Invoke-Help {
     Write-Host "  .\scripts\temuin.ps1 start          # Start everything"
     Write-Host "  .\scripts\temuin.ps1 logs backend    # Tail backend logs"
     Write-Host "  .\scripts\temuin.ps1 seed            # Seed the database"
+    Write-Host "  .\scripts\temuin.ps1 reset           # Nuke DB + pull latest + start fresh"
     Write-Host ""
 }
 
@@ -209,6 +238,7 @@ switch ($Command.ToLower()) {
     "start"   { Invoke-Start }
     "stop"    { Invoke-Stop }
     "restart" { Invoke-Restart }
+    "reset"   { Invoke-Reset }
     "status"  { Invoke-Status }
     "logs"    { Invoke-Logs }
     "build"   { Invoke-Build }

--- a/scripts/temuin.ps1
+++ b/scripts/temuin.ps1
@@ -2,8 +2,8 @@
 # Temuin - Docker Runner Script (PowerShell)
 # ============================================================
 # Usage: .\scripts\temuin.ps1 [command]
-# Commands: start, stop, restart, reset, status, logs, build,
-#           pull, migrate, seed, help
+# Commands: start, stop, restart, status, logs, build, pull,
+#           migrate, seed, help
 # ============================================================
 
 param(
@@ -75,9 +75,7 @@ function Invoke-Start {
     Test-Docker
     Test-EnvFile
     Test-FirebaseCreds
-    # --build ensures images are rebuilt when source code changes (e.g. after git pull)
-    # Data in DB volume is preserved across restarts.
-    docker compose up -d --build
+    docker compose up -d
     Write-Host ""
     Invoke-Status
 }
@@ -94,25 +92,6 @@ function Invoke-Restart {
     Invoke-Stop
     Write-Host ""
     Invoke-Start
-}
-
-function Invoke-Reset {
-    Write-Color "=== Resetting Temuin (full clean restart) ===" "Red"
-    Write-Color "WARNING: This will DELETE the database and all data!" "Yellow"
-    $confirm = Read-Host "Type 'yes' to confirm"
-    if ($confirm -ne "yes") {
-        Write-Color "Reset cancelled." "Yellow"
-        return
-    }
-    Test-Docker
-    Test-EnvFile
-    Test-FirebaseCreds
-    Write-Host "Stopping containers and removing volumes..."
-    docker compose down -v
-    Write-Host "Rebuilding and starting from scratch..."
-    docker compose up -d --build
-    Write-Host ""
-    Invoke-Status
 }
 
 function Invoke-Status {
@@ -204,10 +183,9 @@ function Invoke-Help {
     Write-Host "Usage: " -NoNewline; Write-Color ".\scripts\temuin.ps1" "Green" -NoNewline; Write-Color " [command]" "Yellow"
     Write-Host ""
     Write-Host "Commands:"
-    Write-Host "  " -NoNewline; Write-Color "start" "Green" -NoNewline; Write-Host "              Start all containers (auto-build if code changed)"
-    Write-Host "  " -NoNewline; Write-Color "stop" "Green" -NoNewline; Write-Host "               Stop all containers (data preserved)"
+    Write-Host "  " -NoNewline; Write-Color "start" "Green" -NoNewline; Write-Host "              Start all containers"
+    Write-Host "  " -NoNewline; Write-Color "stop" "Green" -NoNewline; Write-Host "               Stop all containers"
     Write-Host "  " -NoNewline; Write-Color "restart" "Green" -NoNewline; Write-Host "            Restart all containers"
-    Write-Host "  " -NoNewline; Write-Color "reset" "Green" -NoNewline; Write-Host "              Full clean restart (DELETES database!)"
     Write-Host "  " -NoNewline; Write-Color "status" "Green" -NoNewline; Write-Host "             Show container status and URLs"
     Write-Host "  " -NoNewline; Write-Color "logs" "Green" -NoNewline; Write-Host " [service]     Tail logs (optional: db, backend, frontend)"
     Write-Host "  " -NoNewline; Write-Color "build" "Green" -NoNewline; Write-Host "              Build images locally"
@@ -217,10 +195,9 @@ function Invoke-Help {
     Write-Host "  " -NoNewline; Write-Color "help" "Green" -NoNewline; Write-Host "               Show this help message"
     Write-Host ""
     Write-Host "Examples:"
-    Write-Host "  .\scripts\temuin.ps1 start          # Start everything (auto-rebuild)"
+    Write-Host "  .\scripts\temuin.ps1 start          # Start everything"
     Write-Host "  .\scripts\temuin.ps1 logs backend    # Tail backend logs"
     Write-Host "  .\scripts\temuin.ps1 seed            # Seed the database"
-    Write-Host "  .\scripts\temuin.ps1 reset           # Nuke DB + rebuild from scratch"
     Write-Host ""
 }
 
@@ -232,7 +209,6 @@ switch ($Command.ToLower()) {
     "start"   { Invoke-Start }
     "stop"    { Invoke-Stop }
     "restart" { Invoke-Restart }
-    "reset"   { Invoke-Reset }
     "status"  { Invoke-Status }
     "logs"    { Invoke-Logs }
     "build"   { Invoke-Build }

--- a/scripts/temuin.sh
+++ b/scripts/temuin.sh
@@ -3,8 +3,8 @@
 # Temuin - Docker Runner Script (Bash)
 # ============================================================
 # Usage: ./scripts/temuin.sh [command]
-# Commands: start, stop, restart, status, logs, build, pull,
-#           migrate, seed, help
+# Commands: start, stop, restart, reset, status, logs, build,
+#           pull, migrate, seed, help
 # ============================================================
 
 set -e
@@ -51,6 +51,13 @@ check_firebase() {
         echo -e "${YELLOW}WARNING: backend/serviceAccountKey.json not found.${NC}"
         echo "Creating empty placeholder. Firebase auth will NOT work until you add the real file."
         echo '{}' > backend/serviceAccountKey.json
+    else
+        local content
+        content=$(cat backend/serviceAccountKey.json | tr -d '[:space:]')
+        if [ "$content" = "{}" ] || [ ${#content} -lt 50 ]; then
+            echo -e "${YELLOW}WARNING: backend/serviceAccountKey.json appears to be a placeholder.${NC}"
+            echo -e "${YELLOW}Firebase auth will NOT work. Replace with the real credentials file.${NC}"
+        fi
     fi
 }
 
@@ -80,6 +87,27 @@ cmd_restart() {
     cmd_stop
     echo ""
     cmd_start
+}
+
+cmd_reset() {
+    echo -e "${RED}=== Resetting Temuin (full clean restart) ===${NC}"
+    echo -e "${YELLOW}WARNING: This will DELETE the database and all data!${NC}"
+    read -p "Type 'yes' to confirm: " confirm
+    if [ "$confirm" != "yes" ]; then
+        echo -e "${YELLOW}Reset cancelled.${NC}"
+        return
+    fi
+    check_docker
+    check_env
+    check_firebase
+    echo "Stopping containers and removing volumes..."
+    docker compose down -v
+    echo "Pulling latest images..."
+    docker compose pull backend frontend
+    echo "Starting from scratch..."
+    docker compose up -d
+    echo ""
+    cmd_status
 }
 
 cmd_status() {
@@ -169,8 +197,9 @@ cmd_help() {
     echo ""
     echo -e "Commands:"
     echo -e "  ${GREEN}start${NC}              Start all containers"
-    echo -e "  ${GREEN}stop${NC}               Stop all containers"
+    echo -e "  ${GREEN}stop${NC}               Stop all containers (data preserved)"
     echo -e "  ${GREEN}restart${NC}            Restart all containers"
+    echo -e "  ${GREEN}reset${NC}              Full clean restart (DELETES database!)"
     echo -e "  ${GREEN}status${NC}             Show container status and URLs"
     echo -e "  ${GREEN}logs${NC} [service]     Tail logs (optional: db, backend, frontend)"
     echo -e "  ${GREEN}build${NC}              Build images locally"
@@ -183,6 +212,7 @@ cmd_help() {
     echo -e "  ./scripts/temuin.sh start          # Start everything"
     echo -e "  ./scripts/temuin.sh logs backend    # Tail backend logs"
     echo -e "  ./scripts/temuin.sh seed            # Seed the database"
+    echo -e "  ./scripts/temuin.sh reset           # Nuke DB + pull latest + start fresh"
     echo ""
 }
 
@@ -196,6 +226,7 @@ case "$COMMAND" in
     start)    cmd_start ;;
     stop)     cmd_stop ;;
     restart)  cmd_restart ;;
+    reset)    cmd_reset ;;
     status)   cmd_status ;;
     logs)     cmd_logs "$2" ;;
     build)    cmd_build ;;


### PR DESCRIPTION
## Summary

Fix semua masalah Docker auth yang menyebabkan `api-key-not-valid` dan `Invalid Firebase token` di semua laptop tim.

### Root Cause Utama
**`frontend/Dockerfile` tidak convert `ARG` ke `ENV`** — Vite membaca env vars via `process.env`, bukan Docker ARG. Tanpa `ENV VITE_*=$VITE_*`, Firebase config tidak pernah ter-bake ke JS bundle. Semua image yang pernah di-push ke Docker Hub punya dummy config `AIzaSyDummy`.

### Semua Fix

| File | Perubahan | Kenapa |
|------|-----------|--------|
| `frontend/Dockerfile` | Tambah `ENV` setelah `ARG` untuk semua VITE_* vars | **Root cause**: Vite tidak bisa baca Docker ARG, perlu ENV |
| `scripts/temuin.ps1` | Revert `--build` dari `start`, tambah `reset` (pull-based) | `--build` merusak pull-based workflow |
| `scripts/temuin.sh` | Tambah `reset`, improve Firebase creds check | Sinkronkan dengan ps1 |
| `backend/app/auth/firebase.py` | `clock_skew_seconds=5` | Fix "Token used too early" di Docker Desktop |
| `backend/app/main.py` | `/health` return 503 saat DB down | Healthcheck selalu return 200, Docker tidak bisa deteksi unhealthy |
| `backend/Dockerfile` | `start_period` 20s -> 40s | Cegah false unhealthy di mesin lambat |
| `docs/docker-guide.md` | Tambah `reset` ke command table | Keep docs akurat |

### After Merge

DevOps rebuild + push images:
```
.\scripts\temuin.ps1 build
docker push pangeransilaen/temuin-backend:latest
docker push pangeransilaen/temuin-frontend:latest
```

Tim: `pull` -> `start` -> langsung jalan (Firebase config sudah ter-bake dengan benar).

### Testing
- [x] Login berhasil di laptop DevOps setelah full clean (nuke images + pull + build + start)
- [x] Firebase config `AIzaSyDFShPL0...` ter-bake di JS bundle (verified via grep)
- [x] `AIzaSyDummy` tidak lagi muncul di bundle
- [x] Backend healthy, `/health` return 200
- [x] `temuin.ps1 help` menampilkan `reset` command