### PR TITLE
docs: hapus referensi Firebase Auth, update ke email+password

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,4 +44,4 @@ Setiap AI coding agent wajib mulai dari file ini sebelum mengerjakan apa pun di 
 - Skill project-level berada di `.agents/skills/`
 - Skill router proyek: `temuin-router`
 - Skill role-specific: `temuin-backend`, `temuin-frontend`, `temuin-devops`, `temuin-qa-docs`
-- Skill pendukung yang sudah tersedia di workspace ini: `firebase-auth-basics`, `web-design-guidelines`, `design-taste-frontend`, `shadcn`
+- Skill pendukung yang sudah tersedia di workspace ini: `web-design-guidelines`, `design-taste-frontend`, `shadcn`

--- a/temuin-docs/00-ai/AI_GUIDE.md
+++ b/temuin-docs/00-ai/AI_GUIDE.md
@@ -56,7 +56,6 @@ Jika agent mendukung skill project-level, gunakan layer berikut:
 - `temuin-qa-docs` untuk task QA dan dokumentasi
 
 Skill pendukung workspace yang sudah tersedia:
-- `firebase-auth-basics`
 - `web-design-guidelines`
 - `design-taste-frontend`
 - `shadcn`

--- a/temuin-docs/00-ai/SKILLS_SETUP.md
+++ b/temuin-docs/00-ai/SKILLS_SETUP.md
@@ -28,7 +28,6 @@ Di repo ini, folder tersebut sudah tersedia.
 
 | Skill | Fungsi |
 |------|--------|
-| `firebase-auth-basics` | Bantuan Firebase Authentication |
 | `web-design-guidelines` | Review dan kualitas UI |
 | `design-taste-frontend` | Taste dan kualitas desain frontend |
 | `shadcn` | Pola kerja shadcn/ui |
@@ -37,6 +36,5 @@ Di repo ini, folder tersebut sudah tersedia.
 
 - Mulai dari `temuin-router`
 - Jika task sudah jelas per role, panggil skill role yang relevan
-- Untuk auth berbasis Firebase, gabungkan dengan `firebase-auth-basics`
 - Untuk frontend, utamakan `temuin-frontend`, lalu gunakan `shadcn`, `design-taste-frontend`, dan `web-design-guidelines` bila agent mendukung skill tambahan
 - Jika agent tidak mendukung skill system, fallback ke `AGENTS.md` dan dokumen di `temuin-docs/`

--- a/temuin-docs/01-concept/decision-log.md
+++ b/temuin-docs/01-concept/decision-log.md
@@ -8,9 +8,12 @@ Dokumen ini mencatat keputusan final yang tidak boleh dilanggar tanpa keputusan 
 - Sistem hanya dapat diakses setelah login
 - Tidak ada mode anonim atau publik
 
-### DEC-002: Login via Google dan email kampus
-- Hanya akun Google dengan suffix `itk.ac.id` yang boleh masuk
-- User pertama kali otomatis dibuat di database internal dengan role default `user`
+### DEC-002: Login via email kampus
+- Login dan register menggunakan email + password biasa
+- Hanya email dengan suffix `itk.ac.id` yang boleh mendaftar dan masuk
+- Password minimal 8 karakter, harus mengandung huruf dan angka
+- User mendaftar via form register, lalu login via form login
+- Firebase Auth dihapus karena instabilitas (API key suspension, network error di mobile, intermittent failures)
 
 ### DEC-003: Role sistem
 - Role aktif adalah `user`, `admin`, dan `superadmin`

--- a/temuin-docs/03-architecture/backend-architecture.md
+++ b/temuin-docs/03-architecture/backend-architecture.md
@@ -10,24 +10,24 @@
 
 ## Auth Architecture
 
-Temuin memakai **Firebase untuk Google Sign-In** dan **PostgreSQL untuk penyimpanan data internal aplikasi**.
+Temuin memakai **email + password** untuk autentikasi dan **PostgreSQL untuk penyimpanan data internal aplikasi**.
 
 Artinya:
-- Firebase dipakai untuk menjalankan login Google dan menghasilkan Firebase ID token
-- Backend memverifikasi token itu dengan Firebase Admin SDK
-- Setelah token valid, backend melakukan create atau sync user internal di PostgreSQL
-- Backend lalu mengeluarkan JWT internal aplikasi untuk request selanjutnya
+- User mendaftar dan login dengan email kampus (`itk.ac.id`) dan password
+- Backend memverifikasi password dengan bcrypt (via `passlib`)
+- Backend menyimpan `password_hash` di tabel `users` di PostgreSQL
+- Backend mengeluarkan JWT internal aplikasi untuk request selanjutnya
 
-Firebase **bukan** source of truth untuk data domain Temuin. Data seperti items, claims, master data, notifications, audit log, dan role internal tetap berada di PostgreSQL.
+PostgreSQL adalah satu-satunya source of truth untuk data user dan seluruh data domain Temuin.
 
 ## Auth Flow Singkat
 
-1. Frontend login lewat Firebase Auth SDK
-2. Frontend menerima Firebase ID token
-3. Frontend mengirim token itu ke backend
-4. Backend memverifikasi token dengan Firebase Admin SDK
-5. Backend cek email kampus dan aturan internal
-6. Backend create atau sync record user di PostgreSQL
+1. User register via form dengan email `itk.ac.id`, password, dan nama
+2. Backend validasi domain email dan password policy
+3. Backend hash password dengan bcrypt dan simpan user di PostgreSQL
+4. Backend mengembalikan JWT internal ke frontend
+5. Untuk login, user kirim email + password
+6. Backend verifikasi password terhadap hash di database
 7. Backend mengembalikan JWT internal ke frontend
 8. Frontend memakai JWT internal untuk semua request API berikutnya
 
@@ -64,7 +64,7 @@ backend/
 
 ## Boundary Per Modul
 
-- `auth` menangani login Google, user sync, dan JWT internal
+- `auth` menangani register, login email+password, dan JWT internal
 - `items` menangani laporan lost/found dan item status
 - `claims` menangani alur klaim
 - `master_data` menangani kategori, gedung, lokasi, dan satpam
@@ -83,7 +83,7 @@ Pada Sprint 6:
 - Business rule utama wajib mengikuti `decision-log.md`
 - Soft delete untuk item milik user
 - History dan audit log tidak dicampur ke tabel utama
-- Firebase hanya menangani external authentication, bukan penyimpanan data bisnis aplikasi
+- Autentikasi ditangani langsung oleh backend (email+password dengan bcrypt), tanpa dependency eksternal
 
 ## Dokumen Terkait
 

--- a/temuin-docs/03-architecture/database-design.md
+++ b/temuin-docs/03-architecture/database-design.md
@@ -4,7 +4,7 @@
 
 | Tabel | Fungsi |
 |------|--------|
-| `users` | User internal hasil sinkronisasi login |
+| `users` | User internal hasil register/login |
 | `items` | Laporan barang lost/found |
 | `item_images` | Data gambar item disimpan sebagai base64 (DEC-016) |
 | `claims` | Proses klaim item found |
@@ -21,8 +21,9 @@
 
 ### users
 - `id`
-- `firebase_uid`
+- `firebase_uid` (deprecated, nullable - legacy dari Firebase Auth)
 - `email`
+- `password_hash` (bcrypt hash, nullable untuk user lama yang belum re-register)
 - `name`
 - `role`
 - `phone`
@@ -58,8 +59,9 @@
 
 ## Aturan Data
 
-- `users.firebase_uid` menyimpan identitas user dari Firebase Auth
-- User internal tetap disimpan di PostgreSQL walau login memakai Google Sign-In via Firebase
+- `users.firebase_uid` adalah kolom legacy dari Firebase Auth, nullable dan deprecated
+- `users.password_hash` menyimpan bcrypt hash password user
+- User mendaftar dan login langsung dengan email + password
 - `items.type` hanya `lost` atau `found`
 - `items.status` dan `claims.status` dipisahkan
 - `security_officer_id` wajib untuk item `found`

--- a/temuin-docs/03-architecture/frontend-architecture.md
+++ b/temuin-docs/03-architecture/frontend-architecture.md
@@ -9,8 +9,6 @@
 - Tailwind CSS 4
 - shadcn/ui
 - Axios
-- Firebase Auth SDK
-
 Catatan:
 - `shadcn/ui` wajib dipakai sebagai basis komponen UI
 - Jangan membuat sistem UI custom besar jika komponen shadcn sudah cukup
@@ -32,8 +30,7 @@ frontend/
     │   ├── router.jsx
     │   └── providers.jsx
     ├── config/
-    │   ├── api.js
-    │   └── firebase.js
+    │   └── api.js
     ├── components/
     │   ├── ui/
     │   ├── layout/
@@ -75,17 +72,16 @@ frontend/
 
 ## Auth Flow Frontend
 
-1. User klik login Google
-2. Firebase Auth SDK membuka popup Google
-3. Frontend menerima Firebase ID token
-4. Frontend mengirim token itu ke backend
-5. Backend memverifikasi token dan mengembalikan JWT internal aplikasi
-6. Frontend menyimpan JWT internal dan data user internal
-7. Semua request API selanjutnya memakai JWT internal, bukan token Firebase langsung
+1. User register dengan email `itk.ac.id`, password, dan nama via form
+2. Atau user login dengan email dan password via form
+3. Frontend mengirim credentials ke backend (`POST /auth/register` atau `POST /auth/login`)
+4. Backend memverifikasi dan mengembalikan JWT internal aplikasi
+5. Frontend menyimpan JWT internal di `localStorage` dan fetch profil user dari `GET /auth/me`
+6. Semua request API selanjutnya memakai JWT internal via axios interceptor
 
 Catatan:
-- Firebase dipakai untuk proses sign-in
-- PostgreSQL tetap menjadi tempat data user internal dan seluruh data domain Temuin
+- Tidak ada dependency eksternal untuk autentikasi (Firebase dihapus)
+- PostgreSQL adalah satu-satunya tempat data user dan seluruh data domain Temuin
 
 ## Dokumen Terkait
 

--- a/temuin-docs/05-roles/frontend.md
+++ b/temuin-docs/05-roles/frontend.md
@@ -4,7 +4,7 @@
 
 - Bangun UI dan flow user dengan React + Vite
 - Gunakan Tailwind CSS dan shadcn/ui sebagai basis komponen
-- Integrasi Firebase Auth dan API backend
+- Integrasi auth (email+password) dan API backend
 - Jaga UX tetap sederhana, responsif, dan mudah diuji
 
 ## Output Yang Diharapkan


### PR DESCRIPTION
## Summary

Update seluruh dokumen arsitektur untuk merefleksikan keputusan menghapus Firebase Auth dan beralih ke email+password authentication.

## Perubahan

- **DEC-002** diupdate: dari Google Sign-In ke email+password biasa
- **backend-architecture.md**: auth flow berubah ke register/login langsung dengan bcrypt
- **frontend-architecture.md**: hapus Firebase SDK dari stack, update auth flow
- **database-design.md**: tambah `password_hash` field, mark `firebase_uid` deprecated
- **roles/frontend.md**: hapus referensi Firebase Auth
- **AI_GUIDE, SKILLS_SETUP, AGENTS.md**: hapus referensi skill `firebase-auth-basics`

## Alasan

Firebase Auth dihapus karena instabilitas yang tidak bisa dikontrol:
- API key suspension toast muncul random
- Network error di mobile (ngrok) padahal di laptop normal
- Intermittent failures saat buat laporan

Keputusan tim: register dan login biasa dengan email+password, tetap dibatasi domain `itk.ac.id`.

## Catatan

PR ini hanya update docs. Implementasi kode ada di issue terpisah (backend + frontend).
