### PR TITLE
feat(frontend): implement item detail actions (edit, delete, admin status)

### DIFF
--- a/backend/app/items/schemas.py
+++ b/backend/app/items/schemas.py
@@ -23,6 +23,7 @@ class ItemUpdate(BaseModel):
     building_id: Optional[str] = None
     location_id: Optional[str] = None
     security_officer_id: Optional[str] = None
+    status: Optional[str] = Field(None, pattern="^(open|in_claim|returned|closed)$")
     # Assuming update images can be complex, skipping image updates in basic CRUD
     
 class ImageResponse(BaseModel):

--- a/backend/app/items/service.py
+++ b/backend/app/items/service.py
@@ -102,6 +102,9 @@ def update_item(db: Session, item_id: str, user_id: str, user_role: str, item_da
         raise HTTPException(status_code=403, detail="Not authorized to update this item")
         
     update_data_dict = item_data.model_dump(exclude_unset=True)
+    if "status" in update_data_dict and user_role not in ["admin", "superadmin"]:
+        raise HTTPException(status_code=403, detail="Not authorized to update item status")
+
     for key, value in update_data_dict.items():
         setattr(item, key, value)
         

--- a/backend/tests/test_item_service.py
+++ b/backend/tests/test_item_service.py
@@ -1,0 +1,93 @@
+import os
+import unittest
+
+os.environ.setdefault("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+os.environ.setdefault("SECRET_KEY", "test-secret-key")
+
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base
+from app.items.schemas import ItemUpdate
+from app.items.service import update_item
+from app.models.item import Item
+from app.models.master_data import Building, Category, Location, SecurityOfficer
+from app.models.user import User
+
+
+class ItemServiceTest(unittest.TestCase):
+    def setUp(self):
+        self.engine = create_engine("sqlite+pysqlite:///:memory:")
+        TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=self.engine)
+        Base.metadata.create_all(bind=self.engine)
+        self.db = TestingSessionLocal()
+
+        self.owner = User(email="owner@itk.ac.id", name="Owner", role="user")
+        self.admin = User(email="admin@itk.ac.id", name="Admin", role="admin")
+        self.security_officer = SecurityOfficer(name="Pak Budi")
+        self.db.add_all([
+            self.owner,
+            self.admin,
+            Category(name="Elektronik"),
+            Building(name="Gedung A"),
+            Location(name="Lobby"),
+            self.security_officer,
+        ])
+        self.db.commit()
+
+        self.item = Item(
+            type="found",
+            status="open",
+            title="Dompet",
+            description="Dompet hitam",
+            security_officer_id=self.security_officer.id,
+            created_by=self.owner.id,
+        )
+        self.db.add(self.item)
+        self.db.commit()
+        self.db.refresh(self.item)
+
+    def tearDown(self):
+        self.db.close()
+        Base.metadata.drop_all(bind=self.engine)
+        self.engine.dispose()
+
+    def test_owner_can_update_non_status_fields(self):
+        updated_item = update_item(
+            self.db,
+            item_id=self.item.id,
+            user_id=self.owner.id,
+            user_role="user",
+            item_data=ItemUpdate(title="Dompet Kulit"),
+        )
+
+        self.assertEqual(updated_item.title, "Dompet Kulit")
+        self.assertEqual(updated_item.status, "open")
+
+    def test_owner_cannot_update_status(self):
+        with self.assertRaises(HTTPException) as context:
+            update_item(
+                self.db,
+                item_id=self.item.id,
+                user_id=self.owner.id,
+                user_role="user",
+                item_data=ItemUpdate(status="closed"),
+            )
+
+        self.assertEqual(context.exception.status_code, 403)
+
+    def test_admin_can_update_status(self):
+        updated_item = update_item(
+            self.db,
+            item_id=self.item.id,
+            user_id=self.admin.id,
+            user_role="admin",
+            item_data=ItemUpdate(status="returned"),
+        )
+
+        self.assertEqual(updated_item.status, "returned")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/components/items/EditItemDialog.jsx
+++ b/frontend/src/components/items/EditItemDialog.jsx
@@ -6,6 +6,7 @@ import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog"
 import PageState from "@/components/PageState"
+import { toast } from "sonner"
 
 export function EditItemDialog({ isOpen, onClose, item, onSuccess }) {
   const [loading, setLoading] = useState(false)
@@ -48,10 +49,10 @@ export function EditItemDialog({ isOpen, onClose, item, onSuccess }) {
       setMasterDataError(null)
       
       const [catRes, buildRes, locRes, soRes] = await Promise.all([
-        api.get('/master-data/categories'),
-        api.get('/master-data/buildings'),
-        api.get('/master-data/locations'),
-        api.get('/master-data/security-officers'),
+        api.get('/master-data/categories/'),
+        api.get('/master-data/buildings/'),
+        api.get('/master-data/locations/'),
+        api.get('/master-data/security-officers/'),
       ])
       
       setCategories(catRes.data?.data || catRes.data || [])
@@ -90,13 +91,12 @@ export function EditItemDialog({ isOpen, onClose, item, onSuccess }) {
       
       const response = await api.put(`/items/${item.id}`, payload)
       if (response.status === 200) {
-        onSuccess()
+        await onSuccess?.()
       }
     } catch (error) {
       console.error("Error updating item:", error)
       const errorMsg = error.response?.data?.detail || error.response?.data?.message || "Gagal mengupdate laporan. Silakan coba lagi."
-      // Assuming parent will show toast based on error, or we can toast here if we pass toast function
-      throw errorMsg
+      toast.error(errorMsg)
     } finally {
       setLoading(false)
     }

--- a/frontend/src/components/items/EditItemDialog.jsx
+++ b/frontend/src/components/items/EditItemDialog.jsx
@@ -1,0 +1,216 @@
+import { useState, useEffect } from "react"
+import { api } from "@/config/api"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog"
+import PageState from "@/components/PageState"
+
+export function EditItemDialog({ isOpen, onClose, item, onSuccess }) {
+  const [loading, setLoading] = useState(false)
+  
+  const [formData, setFormData] = useState({
+    title: "",
+    description: "",
+    category_id: "",
+    building_id: "",
+    location_id: "",
+    security_officer_id: ""
+  })
+
+  // Master data state
+  const [masterDataLoading, setMasterDataLoading] = useState(false)
+  const [masterDataError, setMasterDataError] = useState(null)
+  
+  const [categories, setCategories] = useState([])
+  const [buildings, setBuildings] = useState([])
+  const [locations, setLocations] = useState([])
+  const [securityOfficers, setSecurityOfficers] = useState([])
+
+  useEffect(() => {
+    if (item && isOpen) {
+      setFormData({
+        title: item.title || "",
+        description: item.description || "",
+        category_id: item.category_id || "",
+        building_id: item.building_id || "",
+        location_id: item.location_id || "",
+        security_officer_id: item.security_officer_id || ""
+      })
+      fetchMasterData()
+    }
+  }, [item, isOpen])
+
+  const fetchMasterData = async () => {
+    try {
+      setMasterDataLoading(true)
+      setMasterDataError(null)
+      
+      const [catRes, buildRes, locRes, soRes] = await Promise.all([
+        api.get('/master-data/categories'),
+        api.get('/master-data/buildings'),
+        api.get('/master-data/locations'),
+        api.get('/master-data/security-officers'),
+      ])
+      
+      setCategories(catRes.data?.data || catRes.data || [])
+      setBuildings(buildRes.data?.data || buildRes.data || [])
+      setLocations(locRes.data?.data || locRes.data || [])
+      setSecurityOfficers(soRes.data?.data || soRes.data || [])
+    } catch (err) {
+      console.error("Error fetching master data:", err)
+      setMasterDataError("Gagal memuat data referensi. Silakan coba lagi.")
+    } finally {
+      setMasterDataLoading(false)
+    }
+  }
+
+  const handleChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value })
+  }
+
+  const handleSelectChange = (name, value) => {
+    setFormData({ ...formData, [name]: value === "_none" ? "" : value })
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    
+    try {
+      setLoading(true)
+      const payload = {
+        title: formData.title,
+        description: formData.description || undefined,
+        category_id: formData.category_id || undefined,
+        building_id: formData.building_id || undefined,
+        location_id: formData.location_id || undefined,
+        security_officer_id: formData.security_officer_id || undefined
+      }
+      
+      const response = await api.put(`/items/${item.id}`, payload)
+      if (response.status === 200) {
+        onSuccess()
+      }
+    } catch (error) {
+      console.error("Error updating item:", error)
+      const errorMsg = error.response?.data?.detail || error.response?.data?.message || "Gagal mengupdate laporan. Silakan coba lagi."
+      // Assuming parent will show toast based on error, or we can toast here if we pass toast function
+      throw errorMsg
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>Edit Laporan</DialogTitle>
+          <DialogDescription>
+            Perbarui detail informasi barang yang hilang atau ditemukan.
+          </DialogDescription>
+        </DialogHeader>
+
+        {masterDataLoading ? (
+           <PageState state="loading" loadingText="Memuat formulir..." />
+        ) : masterDataError ? (
+           <PageState state="error" errorText={masterDataError} onRetry={fetchMasterData} />
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="title">Nama Barang</Label>
+              <Input id="title" name="title" required value={formData.title} onChange={handleChange} placeholder="Contoh: Kunci Motor Honda" />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="description">Deskripsi Lengkap / Spesifik</Label>
+              <textarea 
+                id="description"
+                name="description" 
+                required 
+                value={formData.description} 
+                onChange={handleChange}
+                className="flex w-full min-h-[100px] rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus:ring-2 focus:ring-ring"
+                placeholder="Cantumkan detail ciri-ciri spesifik dan perkiraan lokasi kejadian..."
+              />
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>Kategori (Opsional)</Label>
+                <Select value={formData.category_id || "_none"} onValueChange={(v) => handleSelectChange("category_id", v)}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Pilih Kategori">
+                      {formData.category_id ? categories.find(c => c.id === formData.category_id)?.name || "Pilih Kategori" : "-- Tidak Ada --"}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="_none">-- Tidak Ada --</SelectItem>
+                    {categories.map(c => <SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>)}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label>Gedung (Opsional)</Label>
+                <Select value={formData.building_id || "_none"} onValueChange={(v) => handleSelectChange("building_id", v)}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Pilih Gedung">
+                      {formData.building_id ? buildings.find(b => b.id === formData.building_id)?.name || "Pilih Gedung" : "-- Tidak Ada --"}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="_none">-- Tidak Ada --</SelectItem>
+                    {buildings.map(b => <SelectItem key={b.id} value={b.id}>{b.name}</SelectItem>)}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2 md:col-span-2">
+                <Label>Lokasi Area (Opsional)</Label>
+                <Select value={formData.location_id || "_none"} onValueChange={(v) => handleSelectChange("location_id", v)}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Pilih Lokasi">
+                      {formData.location_id ? locations.find(l => l.id === formData.location_id)?.name || "Pilih Lokasi" : "-- Tidak Ada --"}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="_none">-- Tidak Ada --</SelectItem>
+                    {locations.map(l => <SelectItem key={l.id} value={l.id}>{l.name}</SelectItem>)}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            {item?.type === 'found' && (
+              <div className="space-y-2 p-4 border rounded-md bg-secondary/30">
+                <Label className="font-semibold">
+                  Satpam Penitipan
+                </Label>
+                <Select value={formData.security_officer_id || "_none"} onValueChange={(v) => handleSelectChange("security_officer_id", v)}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Pilih Satpam">
+                      {formData.security_officer_id ? securityOfficers.find(s => s.id === formData.security_officer_id)?.name || "Pilih Satpam" : "-- Pilih Satpam --"}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="_none">-- Pilih Satpam --</SelectItem>
+                    {securityOfficers.map(s => <SelectItem key={s.id} value={s.id}>{s.name}</SelectItem>)}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            <DialogFooter className="pt-4 border-t">
+              <Button type="button" variant="outline" onClick={onClose} disabled={loading}>Batal</Button>
+              <Button type="submit" disabled={loading}>
+                {loading ? "Menyimpan..." : "Simpan Perubahan"}
+              </Button>
+            </DialogFooter>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/ItemDetailPage.jsx
+++ b/frontend/src/pages/ItemDetailPage.jsx
@@ -9,6 +9,8 @@ import { StatusBadge } from "@/components/ui/StatusBadge"
 import PageState from "@/components/PageState"
 import { useAuth } from "@/app/providers"
 import { toast } from "sonner"
+import { EditItemDialog } from "@/components/items/EditItemDialog"
+import { Pencil, Trash2 } from "lucide-react"
 
 export default function ItemDetailPage() {
   const { id } = useParams()
@@ -24,6 +26,10 @@ export default function ItemDetailPage() {
   
   const [claims, setClaims] = useState([])
   const [claimsLoading, setClaimsLoading] = useState(false)
+
+  const [showEditDialog, setShowEditDialog] = useState(false)
+  const [deleteLoading, setDeleteLoading] = useState(false)
+  const [statusUpdateLoading, setStatusUpdateLoading] = useState(false)
 
   const fetchItemAndClaims = async () => {
     try {
@@ -80,6 +86,35 @@ export default function ItemDetailPage() {
     }
   }
 
+  const handleDelete = async () => {
+    if (!window.confirm("Yakin ingin menghapus laporan ini?")) return
+
+    try {
+      setDeleteLoading(true)
+      await api.delete(`/items/${item.id}`)
+      toast.success("Laporan berhasil dihapus!")
+      navigate("/my-items")
+    } catch (error) {
+      console.error("Error deleting item:", error)
+      toast.error("Gagal menghapus laporan.")
+      setDeleteLoading(false)
+    }
+  }
+
+  const handleUpdateStatus = async (newStatus) => {
+    try {
+      setStatusUpdateLoading(true)
+      await api.put(`/items/${item.id}`, { status: newStatus })
+      toast.success("Status berhasil diperbarui!")
+      fetchItemAndClaims()
+    } catch (error) {
+      console.error("Error updating status:", error)
+      toast.error("Gagal memperbarui status.")
+    } finally {
+      setStatusUpdateLoading(false)
+    }
+  }
+
   if (loading) return <PageState state="loading" loadingText="Memuat detail barang..." />
   if (error) return <PageState state="error" errorText={error} onRetry={fetchItemAndClaims} />
   if (!item) return <PageState state="empty" emptyText="Barang tidak ditemukan." />
@@ -89,9 +124,23 @@ export default function ItemDetailPage() {
 
   return (
     <div className="max-w-2xl mx-auto space-y-8">
-      <Button variant="outline" size="sm" onClick={() => navigate(-1)}>
-        Kembali
-      </Button>
+      <div className="flex items-center justify-between">
+        <Button variant="outline" size="sm" onClick={() => navigate(-1)}>
+          Kembali
+        </Button>
+        {isOwner && (
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={() => setShowEditDialog(true)}>
+              <Pencil className="w-4 h-4 mr-2" />
+              Edit
+            </Button>
+            <Button variant="destructive" size="sm" onClick={handleDelete} disabled={deleteLoading}>
+              <Trash2 className="w-4 h-4 mr-2" />
+              {deleteLoading ? "Menghapus..." : "Hapus"}
+            </Button>
+          </div>
+        )}
+      </div>
 
       <div className="flex flex-col gap-4 pb-6 border-b sm:flex-row sm:items-start sm:justify-between">
         <div>
@@ -130,6 +179,50 @@ export default function ItemDetailPage() {
           <h3 className="mb-2 text-lg font-semibold">Keterangan / Deskripsi</h3>
           <p className="leading-relaxed text-muted-foreground">{item.description}</p>
         </div>
+
+        {isAdmin && item.status !== 'closed' && (
+          <div className="pt-6 space-y-4 border-t">
+            <h3 className="text-lg font-semibold">Aksi Admin</h3>
+            <div className="flex flex-wrap gap-2">
+              {item.status === 'open' && (
+                <>
+                  <Button 
+                    variant="outline" 
+                    onClick={() => handleUpdateStatus('returned')}
+                    disabled={statusUpdateLoading}
+                  >
+                    Tandai Dikembalikan
+                  </Button>
+                  <Button 
+                    variant="outline" 
+                    onClick={() => handleUpdateStatus('closed')}
+                    disabled={statusUpdateLoading}
+                  >
+                    Tutup Laporan
+                  </Button>
+                </>
+              )}
+              {item.status === 'in_claim' && (
+                <Button 
+                  variant="outline" 
+                  onClick={() => handleUpdateStatus('closed')}
+                  disabled={statusUpdateLoading}
+                >
+                  Tutup Laporan
+                </Button>
+              )}
+              {item.status === 'returned' && (
+                <Button 
+                  variant="outline" 
+                  onClick={() => handleUpdateStatus('closed')}
+                  disabled={statusUpdateLoading}
+                >
+                  Tutup Laporan
+                </Button>
+              )}
+            </div>
+          </div>
+        )}
 
         {item.type === 'found' && item.status === 'open' && !isOwner && !isAdmin && (
           <div className="pt-6 space-y-4">
@@ -193,6 +286,19 @@ export default function ItemDetailPage() {
           </div>
         )}
       </div>
+
+      {showEditDialog && (
+        <EditItemDialog
+          isOpen={showEditDialog}
+          onClose={() => setShowEditDialog(false)}
+          item={item}
+          onSuccess={() => {
+            toast.success("Laporan berhasil diperbarui!")
+            setShowEditDialog(false)
+            fetchItemAndClaims()
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/ItemDetailPage.jsx
+++ b/frontend/src/pages/ItemDetailPage.jsx
@@ -121,6 +121,7 @@ export default function ItemDetailPage() {
 
   const isAdmin = user?.role === 'admin' || user?.role === 'superadmin'
   const isOwner = user?.id === item.created_by
+  const canCloseItem = isAdmin && ['open', 'in_claim', 'returned'].includes(item.status)
 
   return (
     <div className="max-w-2xl mx-auto space-y-8">
@@ -185,33 +186,15 @@ export default function ItemDetailPage() {
             <h3 className="text-lg font-semibold">Aksi Admin</h3>
             <div className="flex flex-wrap gap-2">
               {item.status === 'open' && (
-                <>
-                  <Button 
-                    variant="outline" 
-                    onClick={() => handleUpdateStatus('returned')}
-                    disabled={statusUpdateLoading}
-                  >
-                    Tandai Dikembalikan
-                  </Button>
-                  <Button 
-                    variant="outline" 
-                    onClick={() => handleUpdateStatus('closed')}
-                    disabled={statusUpdateLoading}
-                  >
-                    Tutup Laporan
-                  </Button>
-                </>
-              )}
-              {item.status === 'in_claim' && (
                 <Button 
                   variant="outline" 
-                  onClick={() => handleUpdateStatus('closed')}
+                  onClick={() => handleUpdateStatus('returned')}
                   disabled={statusUpdateLoading}
                 >
-                  Tutup Laporan
+                  Tandai Dikembalikan
                 </Button>
               )}
-              {item.status === 'returned' && (
+              {canCloseItem && (
                 <Button 
                   variant="outline" 
                   onClick={() => handleUpdateStatus('closed')}


### PR DESCRIPTION
This PR fixes the missing actions on ItemDetailPage based on debugging issue context. 

Changes:
- Added Edit button and EditItemDialog for owners
- Added Delete button and confirmation for owners
- Added Admin Actions section to update item status (open/in_claim/returned/closed)
- Updated ItemUpdate schema in backend to support status changes

Ready for review when the user decides.