### PR TITLE
feat(backend): pytest fixtures + coverage >=60% (BE-5.1, BE-5.2, BE-5.4)

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -1,0 +1,195 @@
+"""
+Temuin backend pytest configuration and shared fixtures.
+
+Per DEC-020: backend coverage threshold 60%. Fixtures here provide:
+- in-memory SQLite engine (per-test isolation)
+- TestClient with `get_db` override
+- Pre-seeded users (regular, admin, superadmin) and master data
+- Helper to create JWT bearer tokens for authenticated requests
+
+Tests should use these fixtures instead of unittest.TestCase setUp/tearDown.
+"""
+
+import os
+
+# Ensure env vars are set BEFORE app modules import config.
+os.environ.setdefault("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+os.environ.setdefault("SECRET_KEY", "test-secret-key-do-not-use-in-prod")
+os.environ.setdefault("ALGORITHM", "HS256")
+os.environ.setdefault("ACCESS_TOKEN_EXPIRE_MINUTES", "60")
+os.environ.setdefault("CORS_ORIGINS", '["http://testserver"]')
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.auth.service import create_access_token, hash_password
+from app.database import Base, get_db
+from app.main import app
+from app.models.item import Item
+from app.models.master_data import Building, Category, Location, SecurityOfficer
+from app.models.user import User
+
+
+@pytest.fixture
+def engine():
+    """In-memory SQLite engine, fresh per test (isolation).
+
+    StaticPool keeps a single connection so the schema persists across
+    sessions within the same test.
+    """
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    try:
+        yield engine
+    finally:
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.fixture
+def db_session(engine):
+    """SQLAlchemy session bound to the in-memory engine."""
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def client(engine, db_session):
+    """FastAPI TestClient with `get_db` overridden to use the in-memory session.
+
+    The override yields the SAME session as `db_session` fixture so tests can
+    seed data via db_session and observe it through HTTP calls.
+    """
+
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass  # session lifecycle handled by db_session fixture
+
+    app.dependency_overrides[get_db] = override_get_db
+    test_client = TestClient(app)
+    try:
+        yield test_client
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ------------------------------------------------------------------
+# User fixtures: pre-seeded with bcrypt password "TestPass123" so
+# tests can exercise both register and login flows without re-hashing.
+# ------------------------------------------------------------------
+
+DEFAULT_PASSWORD = "TestPass123"
+
+
+def _make_user(db, email, name, role):
+    user = User(
+        email=email,
+        name=name,
+        role=role,
+        password_hash=hash_password(DEFAULT_PASSWORD),
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@pytest.fixture
+def auth_user(db_session):
+    """Regular user with role=user."""
+    return _make_user(db_session, "user@itk.ac.id", "Regular User", "user")
+
+
+@pytest.fixture
+def admin_user(db_session):
+    return _make_user(db_session, "admin@itk.ac.id", "Admin User", "admin")
+
+
+@pytest.fixture
+def superadmin_user(db_session):
+    return _make_user(db_session, "superadmin@itk.ac.id", "Super Admin", "superadmin")
+
+
+@pytest.fixture
+def auth_headers(auth_user):
+    """Authorization header for `auth_user`."""
+    return _bearer_for(auth_user)
+
+
+@pytest.fixture
+def admin_headers(admin_user):
+    return _bearer_for(admin_user)
+
+
+@pytest.fixture
+def superadmin_headers(superadmin_user):
+    return _bearer_for(superadmin_user)
+
+
+def _bearer_for(user: User) -> dict:
+    """Generate a valid JWT bearer header for a user."""
+    token = create_access_token(
+        data={"sub": user.email, "role": user.role, "id": user.id}
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ------------------------------------------------------------------
+# Master data fixture - many tests need a SecurityOfficer to create
+# `found` items, plus a Category/Building/Location for filtering.
+# ------------------------------------------------------------------
+
+
+@pytest.fixture
+def master_data(db_session):
+    """Seed minimal master data for item-related tests.
+
+    Returns a dict with keys: category, building, location, security_officer.
+    """
+    category = Category(name="Elektronik")
+    building = Building(name="Gedung A")
+    location = Location(name="Lobby")
+    security_officer = SecurityOfficer(name="Pak Budi")
+    db_session.add_all([category, building, location, security_officer])
+    db_session.commit()
+    for obj in (category, building, location, security_officer):
+        db_session.refresh(obj)
+    return {
+        "category": category,
+        "building": building,
+        "location": location,
+        "security_officer": security_officer,
+    }
+
+
+@pytest.fixture
+def sample_item(db_session, auth_user, master_data):
+    """A persisted `found` Item owned by `auth_user`, status=open."""
+    item = Item(
+        type="found",
+        status="open",
+        title="Dompet Hitam",
+        description="Dompet kulit hitam ditemukan di lobby",
+        category_id=master_data["category"].id,
+        building_id=master_data["building"].id,
+        location_id=master_data["location"].id,
+        security_officer_id=master_data["security_officer"].id,
+        created_by=auth_user.id,
+    )
+    db_session.add(item)
+    db_session.commit()
+    db_session.refresh(item)
+    return item

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,53 @@
+# ===================================================================
+# Temuin Backend - pytest + coverage configuration
+# ===================================================================
+# Per DEC-020: backend test coverage threshold = 60%.
+# Run from backend/ directory: `pytest`
+# ===================================================================
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = [
+    "-v",
+    "--tb=short",
+    "--strict-markers",
+    "--cov=app",
+    "--cov-report=term-missing",
+    "--cov-report=xml",
+    "--cov-fail-under=60",
+]
+markers = [
+    "integration: integration tests that hit the database",
+    "slow: tests that take more than a second",
+]
+filterwarnings = [
+    # Pydantic v2 / SQLAlchemy emit deprecation noise in tests; suppress
+    # only the categories we cannot control to keep CI logs readable.
+    "ignore::DeprecationWarning:passlib.*",
+    "ignore::DeprecationWarning:jose.*",
+]
+
+[tool.coverage.run]
+source = ["app"]
+branch = true
+omit = [
+    "app/__init__.py",
+    "app/*/migrations/*",
+    "app/utils/seed.py",
+    "app/config.py",
+]
+
+[tool.coverage.report]
+precision = 2
+show_missing = true
+skip_covered = false
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,4 +12,5 @@ bcrypt==4.0.1
 # Dev & CI tools
 ruff==0.8.6
 pytest==8.3.4
+pytest-cov==6.0.0
 httpx==0.28.1

--- a/backend/tests/test_auth_service.py
+++ b/backend/tests/test_auth_service.py
@@ -1,112 +1,230 @@
-import unittest
+"""Tests for app.auth — register, login, and /me endpoint.
 
+Refactored from unittest.TestCase to pytest function style + fixtures
+per BE-5.1 (Sprint 5).
+"""
+
+import pytest
 from fastapi import HTTPException
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
 
-from app.database import Base
 from app.auth.service import login_user, register_user
 from app.models.user import User
 
 
-class AuthServiceTest(unittest.TestCase):
-    def setUp(self):
-        self.engine = create_engine("sqlite+pysqlite:///:memory:")
-        TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=self.engine)
-        Base.metadata.create_all(bind=self.engine)
-        self.db = TestingSessionLocal()
-
-    def tearDown(self):
-        self.db.close()
-        Base.metadata.drop_all(bind=self.engine)
-        self.engine.dispose()
-
-    def test_register_user_returns_token_and_persists_hash(self):
-        token = register_user(self.db, "Test@Student.ITK.AC.ID", "abc12345", "Test User")
-
-        user = self.db.query(User).filter(User.email == "test@student.itk.ac.id").first()
-        self.assertIsNotNone(token)
-        self.assertIsNotNone(user)
-        self.assertEqual(user.role, "user")
-        self.assertIsNotNone(user.password_hash)
-        self.assertNotEqual(user.password_hash, "abc12345")
-
-    def test_register_rejects_non_itk_email(self):
-        with self.assertRaises(HTTPException) as context:
-            register_user(self.db, "user@gmail.com", "abc12345", "User")
-
-        self.assertEqual(context.exception.status_code, 403)
-
-    def test_register_rejects_weak_password(self):
-        with self.assertRaises(HTTPException) as context:
-            register_user(self.db, "user@itk.ac.id", "abcdefg", "User")
-
-        self.assertEqual(context.exception.status_code, 400)
-
-    def test_register_existing_user_with_hash_returns_conflict(self):
-        register_user(self.db, "user@itk.ac.id", "abc12345", "User")
-
-        with self.assertRaises(HTTPException) as context:
-            register_user(self.db, "user@itk.ac.id", "abc12345", "Other User")
-
-        self.assertEqual(context.exception.status_code, 409)
-
-    def test_register_legacy_user_sets_first_password(self):
-        legacy_user = User(
-            email="legacy@itk.ac.id",
-            name="Legacy Name",
-            role="user",
-            firebase_uid="legacy-firebase-id",
-            password_hash=None,
-        )
-        self.db.add(legacy_user)
-        self.db.commit()
-
-        token = register_user(self.db, "legacy@itk.ac.id", "abc12345", "Updated Legacy")
-        updated_user = self.db.query(User).filter(User.email == "legacy@itk.ac.id").first()
-
-        self.assertIsNotNone(token)
-        self.assertEqual(updated_user.name, "Updated Legacy")
-        self.assertIsNotNone(updated_user.password_hash)
-
-    def test_login_user_returns_token_for_valid_credentials(self):
-        register_user(self.db, "user@itk.ac.id", "abc12345", "User")
-
-        token = login_user(self.db, "user@itk.ac.id", "abc12345")
-
-        self.assertIsNotNone(token)
-
-    def test_login_rejects_unknown_email(self):
-        with self.assertRaises(HTTPException) as context:
-            login_user(self.db, "missing@itk.ac.id", "abc12345")
-
-        self.assertEqual(context.exception.status_code, 401)
-
-    def test_login_rejects_wrong_password(self):
-        register_user(self.db, "user@itk.ac.id", "abc12345", "User")
-
-        with self.assertRaises(HTTPException) as context:
-            login_user(self.db, "user@itk.ac.id", "wrong123")
-
-        self.assertEqual(context.exception.status_code, 401)
-
-    def test_login_rejects_legacy_user_without_password(self):
-        legacy_user = User(
-            email="legacy@itk.ac.id",
-            name="Legacy User",
-            role="user",
-            firebase_uid="legacy-firebase-id",
-            password_hash=None,
-        )
-        self.db.add(legacy_user)
-        self.db.commit()
-
-        with self.assertRaises(HTTPException) as context:
-            login_user(self.db, "legacy@itk.ac.id", "abc12345")
-
-        self.assertEqual(context.exception.status_code, 401)
-        self.assertIn("register", context.exception.detail.lower())
+# ------------------------------------------------------------------
+# register_user service-level tests
+# ------------------------------------------------------------------
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_register_user_returns_token_and_persists_hash(db_session):
+    token = register_user(db_session, "Test@Student.ITK.AC.ID", "abc12345", "Test User")
+
+    user = db_session.query(User).filter(User.email == "test@student.itk.ac.id").first()
+    assert token is not None
+    assert user is not None
+    assert user.role == "user"
+    assert user.password_hash is not None
+    assert user.password_hash != "abc12345"
+
+
+def test_register_rejects_non_itk_email(db_session):
+    with pytest.raises(HTTPException) as exc_info:
+        register_user(db_session, "user@gmail.com", "abc12345", "User")
+
+    assert exc_info.value.status_code == 403
+
+
+def test_register_rejects_weak_password(db_session):
+    with pytest.raises(HTTPException) as exc_info:
+        register_user(db_session, "user@itk.ac.id", "abcdefg", "User")
+
+    assert exc_info.value.status_code == 400
+
+
+def test_register_rejects_password_without_digit(db_session):
+    with pytest.raises(HTTPException) as exc_info:
+        register_user(db_session, "user@itk.ac.id", "abcdefghij", "User")
+
+    assert exc_info.value.status_code == 400
+
+
+def test_register_existing_user_with_hash_returns_conflict(db_session):
+    register_user(db_session, "user@itk.ac.id", "abc12345", "User")
+
+    with pytest.raises(HTTPException) as exc_info:
+        register_user(db_session, "user@itk.ac.id", "abc12345", "Other User")
+
+    assert exc_info.value.status_code == 409
+
+
+def test_register_legacy_user_sets_first_password(db_session):
+    legacy_user = User(
+        email="legacy@itk.ac.id",
+        name="Legacy Name",
+        role="user",
+        firebase_uid="legacy-firebase-id",
+        password_hash=None,
+    )
+    db_session.add(legacy_user)
+    db_session.commit()
+
+    token = register_user(db_session, "legacy@itk.ac.id", "abc12345", "Updated Legacy")
+    updated_user = db_session.query(User).filter(User.email == "legacy@itk.ac.id").first()
+
+    assert token is not None
+    assert updated_user.name == "Updated Legacy"
+    assert updated_user.password_hash is not None
+
+
+# ------------------------------------------------------------------
+# login_user service-level tests
+# ------------------------------------------------------------------
+
+
+def test_login_user_returns_token_for_valid_credentials(db_session):
+    register_user(db_session, "user@itk.ac.id", "abc12345", "User")
+
+    token = login_user(db_session, "user@itk.ac.id", "abc12345")
+
+    assert token is not None
+
+
+def test_login_rejects_unknown_email(db_session):
+    with pytest.raises(HTTPException) as exc_info:
+        login_user(db_session, "missing@itk.ac.id", "abc12345")
+
+    assert exc_info.value.status_code == 401
+
+
+def test_login_rejects_wrong_password(db_session):
+    register_user(db_session, "user@itk.ac.id", "abc12345", "User")
+
+    with pytest.raises(HTTPException) as exc_info:
+        login_user(db_session, "user@itk.ac.id", "wrong123")
+
+    assert exc_info.value.status_code == 401
+
+
+def test_login_rejects_legacy_user_without_password(db_session):
+    legacy_user = User(
+        email="legacy@itk.ac.id",
+        name="Legacy User",
+        role="user",
+        firebase_uid="legacy-firebase-id",
+        password_hash=None,
+    )
+    db_session.add(legacy_user)
+    db_session.commit()
+
+    with pytest.raises(HTTPException) as exc_info:
+        login_user(db_session, "legacy@itk.ac.id", "abc12345")
+
+    assert exc_info.value.status_code == 401
+    assert "register" in exc_info.value.detail.lower()
+
+
+# ------------------------------------------------------------------
+# HTTP-level tests (TestClient): register, login, /me
+# Added per BE-5.1 (Sprint 5) coverage of HTTP layer.
+# ------------------------------------------------------------------
+
+
+def test_register_endpoint_returns_token(client):
+    response = client.post(
+        "/auth/register",
+        json={
+            "email": "newuser@itk.ac.id",
+            "password": "abc12345",
+            "name": "New User",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "access_token" in body
+    assert body["access_token"]
+
+
+def test_register_endpoint_rejects_invalid_email(client):
+    response = client.post(
+        "/auth/register",
+        json={
+            "email": "outsider@gmail.com",
+            "password": "abc12345",
+            "name": "Outsider",
+        },
+    )
+
+    assert response.status_code == 403
+
+
+def test_login_endpoint_returns_token(client):
+    client.post(
+        "/auth/register",
+        json={"email": "login@itk.ac.id", "password": "abc12345", "name": "Login"},
+    )
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "login@itk.ac.id", "password": "abc12345"},
+    )
+
+    assert response.status_code == 200
+    assert "access_token" in response.json()
+
+
+def test_login_endpoint_rejects_wrong_password(client):
+    client.post(
+        "/auth/register",
+        json={"email": "login2@itk.ac.id", "password": "abc12345", "name": "Login"},
+    )
+
+    response = client.post(
+        "/auth/login",
+        json={"email": "login2@itk.ac.id", "password": "wrong123"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_get_me_returns_current_user_profile(client, auth_user, auth_headers):
+    response = client.get("/auth/me", headers=auth_headers)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["email"] == auth_user.email
+    assert body["name"] == auth_user.name
+    assert body["role"] == "user"
+
+
+def test_get_me_rejects_missing_token(client):
+    response = client.get("/auth/me")
+
+    # FastAPI HTTPBearer raises 403 when no Authorization header
+    assert response.status_code in (401, 403)
+
+
+def test_get_me_rejects_invalid_token(client):
+    response = client.get(
+        "/auth/me",
+        headers={"Authorization": "Bearer not-a-real-token"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_update_me_changes_profile_fields(client, auth_user, auth_headers, db_session):
+    response = client.put(
+        "/auth/me",
+        headers=auth_headers,
+        json={"name": "Updated Name", "phone": "081234567890"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "Updated Name"
+    assert body["phone"] == "081234567890"
+
+    db_session.refresh(auth_user)
+    assert auth_user.name == "Updated Name"
+    assert auth_user.phone == "081234567890"

--- a/backend/tests/test_claim_service.py
+++ b/backend/tests/test_claim_service.py
@@ -1,164 +1,276 @@
-import os
-import unittest
+"""Tests for app.claims — service-layer notifications + HTTP claim flow.
 
-os.environ.setdefault("DATABASE_URL", "sqlite+pysqlite:///:memory:")
-os.environ.setdefault("SECRET_KEY", "test-secret-key")
+Refactored to pytest function style + fixtures per BE-5.1.
+HTTP-level tests for claim flow (create -> approve, unauthorized) per BE-5.2.
+"""
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+import pytest
 
 from app.claims.schemas import ClaimCreate, ClaimStatusUpdate
 from app.claims.service import create_claim, update_claim_status
-from app.database import Base
 from app.models.item import Item
 from app.models.master_data import SecurityOfficer
 from app.models.notification import Notification
 from app.models.user import User
 
 
-class ClaimServiceNotificationTest(unittest.TestCase):
-    def setUp(self):
-        self.engine = create_engine("sqlite+pysqlite:///:memory:")
-        testing_session_local = sessionmaker(
-            autocommit=False,
-            autoflush=False,
-            bind=self.engine,
-        )
-        Base.metadata.create_all(bind=self.engine)
-        self.db = testing_session_local()
-
-        self.owner = User(email="owner@itk.ac.id", name="Owner", role="user")
-        self.claimant = User(email="claimant@itk.ac.id", name="Claimant", role="user")
-        self.admin = User(email="admin@itk.ac.id", name="Admin", role="admin")
-        self.superadmin = User(email="superadmin@itk.ac.id", name="Superadmin", role="superadmin")
-        self.security_officer = SecurityOfficer(name="Pak Budi")
-
-        self.db.add_all(
-            [
-                self.owner,
-                self.claimant,
-                self.admin,
-                self.superadmin,
-                self.security_officer,
-            ]
-        )
-        self.db.commit()
-
-        self.item = Item(
-            type="found",
-            status="open",
-            title="Dompet Hitam",
-            description="Dompet hitam di lobby",
-            security_officer_id=self.security_officer.id,
-            created_by=self.owner.id,
-        )
-        self.db.add(self.item)
-        self.db.commit()
-        self.db.refresh(self.item)
-
-    def tearDown(self):
-        self.db.close()
-        Base.metadata.drop_all(bind=self.engine)
-        self.engine.dispose()
-
-    def _messages_for_user(self, user_id):
-        return self.db.query(Notification).filter(Notification.user_id == user_id).all()
-
-    def test_create_claim_creates_notifications_for_owner_and_admins(self):
-        create_claim(
-            self.db,
-            user_id=self.claimant.id,
-            claim_in=ClaimCreate(item_id=self.item.id, ownership_answer="Ciri dompet saya ada kartu kampus"),
-        )
-
-        owner_notifications = self._messages_for_user(self.owner.id)
-        admin_notifications = self._messages_for_user(self.admin.id)
-        superadmin_notifications = self._messages_for_user(self.superadmin.id)
-        claimant_notifications = self._messages_for_user(self.claimant.id)
-
-        self.assertEqual(len(owner_notifications), 1)
-        self.assertEqual(owner_notifications[0].title, "Klaim Baru pada Barang Anda")
-        self.assertEqual(len(admin_notifications), 1)
-        self.assertEqual(admin_notifications[0].title, "Klaim Baru Masuk")
-        self.assertEqual(len(superadmin_notifications), 1)
-        self.assertEqual(superadmin_notifications[0].title, "Klaim Baru Masuk")
-        self.assertEqual(len(claimant_notifications), 0)
-
-    def test_update_claim_status_creates_notifications_for_claim_owner_and_item_owner(self):
-        claim = create_claim(
-            self.db,
-            user_id=self.claimant.id,
-            claim_in=ClaimCreate(item_id=self.item.id, ownership_answer="Saya tahu isi dompetnya"),
-        )
-        self.db.query(Notification).delete()
-        self.db.commit()
-
-        update_claim_status(
-            self.db,
-            claim_id=claim.id,
-            payload=ClaimStatusUpdate(status="approved"),
-            user_id=self.admin.id,
-        )
-
-        owner_notifications = self._messages_for_user(self.owner.id)
-        claimant_notifications = self._messages_for_user(self.claimant.id)
-        admin_notifications = self._messages_for_user(self.admin.id)
-
-        self.assertEqual(len(claimant_notifications), 1)
-        self.assertEqual(claimant_notifications[0].title, "Klaim Disetujui")
-        self.assertEqual(len(owner_notifications), 1)
-        self.assertEqual(owner_notifications[0].title, "Update Status Klaim")
-        self.assertEqual(len(admin_notifications), 0)
-
-    def test_create_claim_skips_duplicate_notification_when_admin_is_item_owner(self):
-        """Admin yang juga item owner tidak boleh dapat 2 notif (owner + admin)."""
-        admin_item = Item(
-            type="found",
-            status="open",
-            title="Laptop di Perpustakaan",
-            description="Laptop ditemukan di perpustakaan",
-            security_officer_id=self.security_officer.id,
-            created_by=self.admin.id,
-        )
-        self.db.add(admin_item)
-        self.db.commit()
-        self.db.refresh(admin_item)
-
-        create_claim(
-            self.db,
-            user_id=self.claimant.id,
-            claim_in=ClaimCreate(item_id=admin_item.id, ownership_answer="Laptop saya warna hitam"),
-        )
-
-        admin_notifications = self._messages_for_user(self.admin.id)
-        # Admin sebagai item owner dapat 1 notif "Klaim Baru pada Barang Anda"
-        # Tapi TIDAK dapat notif tambahan "Klaim Baru Masuk" sebagai admin
-        self.assertEqual(len(admin_notifications), 1)
-        self.assertEqual(admin_notifications[0].title, "Klaim Baru pada Barang Anda")
-
-    def test_update_claim_status_skips_self_notification_for_item_owner(self):
-        claim = create_claim(
-            self.db,
-            user_id=self.claimant.id,
-            claim_in=ClaimCreate(item_id=self.item.id, ownership_answer="Ada gantungan kunci merah"),
-        )
-        self.db.query(Notification).delete()
-        self.db.commit()
-
-        update_claim_status(
-            self.db,
-            claim_id=claim.id,
-            payload=ClaimStatusUpdate(status="approved"),
-            user_id=self.owner.id,
-        )
-
-        owner_notifications = self._messages_for_user(self.owner.id)
-        claimant_notifications = self._messages_for_user(self.claimant.id)
-
-        self.assertEqual(len(claimant_notifications), 1)
-        self.assertEqual(claimant_notifications[0].title, "Klaim Disetujui")
-        self.assertEqual(len(owner_notifications), 0)
+# ------------------------------------------------------------------
+# Fixtures specific to claim service tests
+# ------------------------------------------------------------------
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.fixture
+def claim_setup(db_session):
+    """Seed: owner, claimant, admin, superadmin, security officer, found item."""
+    owner = User(email="owner@itk.ac.id", name="Owner", role="user")
+    claimant = User(email="claimant@itk.ac.id", name="Claimant", role="user")
+    admin = User(email="admin@itk.ac.id", name="Admin", role="admin")
+    superadmin = User(email="superadmin@itk.ac.id", name="Superadmin", role="superadmin")
+    security_officer = SecurityOfficer(name="Pak Budi")
+
+    db_session.add_all([owner, claimant, admin, superadmin, security_officer])
+    db_session.commit()
+
+    item = Item(
+        type="found",
+        status="open",
+        title="Dompet Hitam",
+        description="Dompet hitam di lobby",
+        security_officer_id=security_officer.id,
+        created_by=owner.id,
+    )
+    db_session.add(item)
+    db_session.commit()
+    db_session.refresh(item)
+
+    return {
+        "owner": owner,
+        "claimant": claimant,
+        "admin": admin,
+        "superadmin": superadmin,
+        "security_officer": security_officer,
+        "item": item,
+    }
+
+
+def _messages_for_user(db_session, user_id):
+    return db_session.query(Notification).filter(Notification.user_id == user_id).all()
+
+
+# ------------------------------------------------------------------
+# Notification logic tests (existing, refactored)
+# ------------------------------------------------------------------
+
+
+def test_create_claim_creates_notifications_for_owner_and_admins(db_session, claim_setup):
+    create_claim(
+        db_session,
+        user_id=claim_setup["claimant"].id,
+        claim_in=ClaimCreate(
+            item_id=claim_setup["item"].id,
+            ownership_answer="Ciri dompet saya ada kartu kampus",
+        ),
+    )
+
+    owner_notifications = _messages_for_user(db_session, claim_setup["owner"].id)
+    admin_notifications = _messages_for_user(db_session, claim_setup["admin"].id)
+    superadmin_notifications = _messages_for_user(db_session, claim_setup["superadmin"].id)
+    claimant_notifications = _messages_for_user(db_session, claim_setup["claimant"].id)
+
+    assert len(owner_notifications) == 1
+    assert owner_notifications[0].title == "Klaim Baru pada Barang Anda"
+    assert len(admin_notifications) == 1
+    assert admin_notifications[0].title == "Klaim Baru Masuk"
+    assert len(superadmin_notifications) == 1
+    assert superadmin_notifications[0].title == "Klaim Baru Masuk"
+    assert len(claimant_notifications) == 0
+
+
+def test_update_claim_status_creates_notifications_for_claim_owner_and_item_owner(
+    db_session, claim_setup
+):
+    claim = create_claim(
+        db_session,
+        user_id=claim_setup["claimant"].id,
+        claim_in=ClaimCreate(
+            item_id=claim_setup["item"].id,
+            ownership_answer="Saya tahu isi dompetnya",
+        ),
+    )
+    db_session.query(Notification).delete()
+    db_session.commit()
+
+    update_claim_status(
+        db_session,
+        claim_id=claim.id,
+        payload=ClaimStatusUpdate(status="approved"),
+        user_id=claim_setup["admin"].id,
+    )
+
+    owner_notifications = _messages_for_user(db_session, claim_setup["owner"].id)
+    claimant_notifications = _messages_for_user(db_session, claim_setup["claimant"].id)
+    admin_notifications = _messages_for_user(db_session, claim_setup["admin"].id)
+
+    assert len(claimant_notifications) == 1
+    assert claimant_notifications[0].title == "Klaim Disetujui"
+    assert len(owner_notifications) == 1
+    assert owner_notifications[0].title == "Update Status Klaim"
+    assert len(admin_notifications) == 0
+
+
+def test_create_claim_skips_duplicate_notification_when_admin_is_item_owner(
+    db_session, claim_setup
+):
+    """Admin yang juga item owner tidak boleh dapat 2 notif (owner + admin)."""
+    admin_item = Item(
+        type="found",
+        status="open",
+        title="Laptop di Perpustakaan",
+        description="Laptop ditemukan di perpustakaan",
+        security_officer_id=claim_setup["security_officer"].id,
+        created_by=claim_setup["admin"].id,
+    )
+    db_session.add(admin_item)
+    db_session.commit()
+    db_session.refresh(admin_item)
+
+    create_claim(
+        db_session,
+        user_id=claim_setup["claimant"].id,
+        claim_in=ClaimCreate(
+            item_id=admin_item.id, ownership_answer="Laptop saya warna hitam"
+        ),
+    )
+
+    admin_notifications = _messages_for_user(db_session, claim_setup["admin"].id)
+    assert len(admin_notifications) == 1
+    assert admin_notifications[0].title == "Klaim Baru pada Barang Anda"
+
+
+def test_update_claim_status_skips_self_notification_for_item_owner(
+    db_session, claim_setup
+):
+    claim = create_claim(
+        db_session,
+        user_id=claim_setup["claimant"].id,
+        claim_in=ClaimCreate(
+            item_id=claim_setup["item"].id,
+            ownership_answer="Ada gantungan kunci merah",
+        ),
+    )
+    db_session.query(Notification).delete()
+    db_session.commit()
+
+    update_claim_status(
+        db_session,
+        claim_id=claim.id,
+        payload=ClaimStatusUpdate(status="approved"),
+        user_id=claim_setup["owner"].id,
+    )
+
+    owner_notifications = _messages_for_user(db_session, claim_setup["owner"].id)
+    claimant_notifications = _messages_for_user(db_session, claim_setup["claimant"].id)
+
+    assert len(claimant_notifications) == 1
+    assert claimant_notifications[0].title == "Klaim Disetujui"
+    assert len(owner_notifications) == 0
+
+
+# ------------------------------------------------------------------
+# HTTP-level claim flow tests (BE-5.2)
+# ------------------------------------------------------------------
+
+
+def _bearer(user):
+    """Inline JWT helper to avoid coupling to conftest._bearer_for."""
+    from app.auth.service import create_access_token
+
+    token = create_access_token(
+        data={"sub": user.email, "role": user.role, "id": user.id}
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_create_claim_endpoint_returns_201_and_persists(client, claim_setup):
+    response = client.post(
+        "/claims/",
+        headers=_bearer(claim_setup["claimant"]),
+        json={
+            "item_id": claim_setup["item"].id,
+            "ownership_answer": "Saya yakin itu punya saya, ada inisial AB",
+        },
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["item_id"] == claim_setup["item"].id
+    assert body["user_id"] == claim_setup["claimant"].id
+    assert body["status"] == "pending"
+
+
+def test_create_claim_rejected_when_unauthenticated(client, claim_setup):
+    response = client.post(
+        "/claims/",
+        json={
+            "item_id": claim_setup["item"].id,
+            "ownership_answer": "test",
+        },
+    )
+
+    assert response.status_code in (401, 403)
+
+
+def test_admin_can_approve_claim_via_http(client, claim_setup, db_session):
+    create_resp = client.post(
+        "/claims/",
+        headers=_bearer(claim_setup["claimant"]),
+        json={
+            "item_id": claim_setup["item"].id,
+            "ownership_answer": "Saya yakin punya saya",
+        },
+    )
+    assert create_resp.status_code == 201
+    claim_id = create_resp.json()["id"]
+
+    approve_resp = client.put(
+        f"/claims/{claim_id}/status",
+        headers=_bearer(claim_setup["admin"]),
+        json={"status": "approved"},
+    )
+
+    assert approve_resp.status_code == 200
+    assert approve_resp.json()["status"] == "approved"
+
+    # Verify item status synced
+    db_session.expire_all()
+    item = db_session.query(Item).filter(Item.id == claim_setup["item"].id).first()
+    assert item.status == "in_claim"
+
+
+def test_get_my_claims_returns_only_users_own_claims(client, claim_setup):
+    client.post(
+        "/claims/",
+        headers=_bearer(claim_setup["claimant"]),
+        json={
+            "item_id": claim_setup["item"].id,
+            "ownership_answer": "test",
+        },
+    )
+
+    response = client.get("/claims/me", headers=_bearer(claim_setup["claimant"]))
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 1
+    assert body[0]["user_id"] == claim_setup["claimant"].id
+
+    # Different user sees nothing
+    response_owner = client.get(
+        "/claims/me", headers=_bearer(claim_setup["owner"])
+    )
+    assert response_owner.status_code == 200
+    assert len(response_owner.json()) == 0
+
+
+def test_get_my_claims_rejected_when_unauthenticated(client):
+    response = client.get("/claims/me")
+    assert response.status_code in (401, 403)

--- a/backend/tests/test_item_service.py
+++ b/backend/tests/test_item_service.py
@@ -1,93 +1,262 @@
-import os
-import unittest
+"""Tests for app.items — service layer + HTTP CRUD.
 
-os.environ.setdefault("DATABASE_URL", "sqlite+pysqlite:///:memory:")
-os.environ.setdefault("SECRET_KEY", "test-secret-key")
+Refactored to pytest function style + fixtures per BE-5.1.
+HTTP-level CRUD tests added per BE-5.2 (Sprint 5).
+"""
 
+import pytest
 from fastapi import HTTPException
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
 
-from app.database import Base
 from app.items.schemas import ItemUpdate
 from app.items.service import update_item
-from app.models.item import Item
-from app.models.master_data import Building, Category, Location, SecurityOfficer
-from app.models.user import User
 
 
-class ItemServiceTest(unittest.TestCase):
-    def setUp(self):
-        self.engine = create_engine("sqlite+pysqlite:///:memory:")
-        TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=self.engine)
-        Base.metadata.create_all(bind=self.engine)
-        self.db = TestingSessionLocal()
+# ------------------------------------------------------------------
+# Service-layer authorization tests (existing, refactored)
+# ------------------------------------------------------------------
 
-        self.owner = User(email="owner@itk.ac.id", name="Owner", role="user")
-        self.admin = User(email="admin@itk.ac.id", name="Admin", role="admin")
-        self.security_officer = SecurityOfficer(name="Pak Budi")
-        self.db.add_all([
-            self.owner,
-            self.admin,
-            Category(name="Elektronik"),
-            Building(name="Gedung A"),
-            Location(name="Lobby"),
-            self.security_officer,
-        ])
-        self.db.commit()
 
-        self.item = Item(
-            type="found",
-            status="open",
-            title="Dompet",
-            description="Dompet hitam",
-            security_officer_id=self.security_officer.id,
-            created_by=self.owner.id,
-        )
-        self.db.add(self.item)
-        self.db.commit()
-        self.db.refresh(self.item)
+def test_owner_can_update_non_status_fields(db_session, auth_user, sample_item):
+    updated_item = update_item(
+        db_session,
+        item_id=sample_item.id,
+        user_id=auth_user.id,
+        user_role="user",
+        item_data=ItemUpdate(title="Dompet Kulit"),
+    )
 
-    def tearDown(self):
-        self.db.close()
-        Base.metadata.drop_all(bind=self.engine)
-        self.engine.dispose()
+    assert updated_item.title == "Dompet Kulit"
+    assert updated_item.status == "open"
 
-    def test_owner_can_update_non_status_fields(self):
-        updated_item = update_item(
-            self.db,
-            item_id=self.item.id,
-            user_id=self.owner.id,
+
+def test_owner_cannot_update_status(db_session, auth_user, sample_item):
+    with pytest.raises(HTTPException) as exc_info:
+        update_item(
+            db_session,
+            item_id=sample_item.id,
+            user_id=auth_user.id,
             user_role="user",
-            item_data=ItemUpdate(title="Dompet Kulit"),
+            item_data=ItemUpdate(status="closed"),
         )
 
-        self.assertEqual(updated_item.title, "Dompet Kulit")
-        self.assertEqual(updated_item.status, "open")
-
-    def test_owner_cannot_update_status(self):
-        with self.assertRaises(HTTPException) as context:
-            update_item(
-                self.db,
-                item_id=self.item.id,
-                user_id=self.owner.id,
-                user_role="user",
-                item_data=ItemUpdate(status="closed"),
-            )
-
-        self.assertEqual(context.exception.status_code, 403)
-
-    def test_admin_can_update_status(self):
-        updated_item = update_item(
-            self.db,
-            item_id=self.item.id,
-            user_id=self.admin.id,
-            user_role="admin",
-            item_data=ItemUpdate(status="returned"),
-        )
-
-        self.assertEqual(updated_item.status, "returned")
+    assert exc_info.value.status_code == 403
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_admin_can_update_status(db_session, admin_user, sample_item):
+    updated_item = update_item(
+        db_session,
+        item_id=sample_item.id,
+        user_id=admin_user.id,
+        user_role="admin",
+        item_data=ItemUpdate(status="returned"),
+    )
+
+    assert updated_item.status == "returned"
+
+
+# ------------------------------------------------------------------
+# HTTP-level CRUD tests (BE-5.2: list, create, detail, unauthorized)
+# ------------------------------------------------------------------
+
+
+def test_create_found_item_requires_security_officer(client, auth_headers):
+    response = client.post(
+        "/items/",
+        headers=auth_headers,
+        json={
+            "type": "found",
+            "title": "Dompet Tanpa Officer",
+            "description": "Dompet di lobby",
+            # security_officer_id missing -> service raises 400
+        },
+    )
+
+    assert response.status_code == 400
+    assert "security_officer_id" in response.json()["detail"]
+
+
+def test_create_lost_item_does_not_require_security_officer(client, auth_headers):
+    response = client.post(
+        "/items/",
+        headers=auth_headers,
+        json={
+            "type": "lost",
+            "title": "Kunci Motor Hilang",
+            "description": "Hilang di parkiran",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["type"] == "lost"
+    assert body["status"] == "open"
+    assert body["title"] == "Kunci Motor Hilang"
+
+
+def test_create_found_item_with_security_officer_succeeds(
+    client, auth_headers, master_data
+):
+    response = client.post(
+        "/items/",
+        headers=auth_headers,
+        json={
+            "type": "found",
+            "title": "Tas Ransel",
+            "description": "Tas ransel hitam di kantin",
+            "category_id": master_data["category"].id,
+            "building_id": master_data["building"].id,
+            "location_id": master_data["location"].id,
+            "security_officer_id": master_data["security_officer"].id,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["type"] == "found"
+    assert body["security_officer_id"] == master_data["security_officer"].id
+
+
+def test_create_item_rejected_when_unauthenticated(client):
+    response = client.post(
+        "/items/",
+        json={"type": "lost", "title": "Test", "description": "Test"},
+    )
+
+    # Missing Authorization -> HTTPBearer rejects (401 or 403)
+    assert response.status_code in (401, 403)
+
+
+def test_list_items_returns_array(client, sample_item):
+    response = client.get("/items/")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body, list)
+    assert len(body) == 1
+    assert body[0]["id"] == sample_item.id
+    assert body[0]["title"] == "Dompet Hitam"
+
+
+def test_list_items_supports_search(client, sample_item):
+    response = client.get("/items/?search=dompet")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 1
+    assert body[0]["id"] == sample_item.id
+
+
+def test_list_items_filter_by_type(client, sample_item):
+    # sample_item is type=found
+    response_found = client.get("/items/?type=found")
+    response_lost = client.get("/items/?type=lost")
+
+    assert response_found.status_code == 200
+    assert response_lost.status_code == 200
+    assert len(response_found.json()) == 1
+    assert len(response_lost.json()) == 0
+
+
+def test_get_item_detail_returns_item(client, sample_item):
+    response = client.get(f"/items/{sample_item.id}")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == sample_item.id
+    assert body["title"] == sample_item.title
+
+
+def test_get_item_detail_returns_404_for_missing_id(client):
+    response = client.get("/items/non-existent-id")
+
+    assert response.status_code == 404
+
+
+def test_list_my_items_returns_only_users_own_items(
+    client, auth_user, auth_headers, sample_item
+):
+    response = client.get("/items/me", headers=auth_headers)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 1
+    assert body[0]["id"] == sample_item.id
+    assert body[0]["created_by"] == auth_user.id
+
+
+def test_list_my_items_rejected_when_unauthenticated(client):
+    response = client.get("/items/me")
+
+    assert response.status_code in (401, 403)
+
+
+def test_update_item_via_http_changes_title(
+    client, auth_headers, sample_item, db_session
+):
+    response = client.put(
+        f"/items/{sample_item.id}",
+        headers=auth_headers,
+        json={"title": "Dompet Baru"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["title"] == "Dompet Baru"
+
+
+def test_update_item_status_rejected_for_owner_role_user(
+    client, auth_headers, sample_item
+):
+    response = client.put(
+        f"/items/{sample_item.id}",
+        headers=auth_headers,
+        json={"status": "closed"},
+    )
+
+    assert response.status_code == 403
+
+
+def test_update_item_status_succeeds_for_admin(
+    client, admin_headers, sample_item
+):
+    response = client.put(
+        f"/items/{sample_item.id}",
+        headers=admin_headers,
+        json={"status": "returned"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "returned"
+
+
+def test_delete_item_by_owner_succeeds(client, auth_headers, sample_item):
+    response = client.delete(f"/items/{sample_item.id}", headers=auth_headers)
+
+    assert response.status_code == 204
+
+    # Verify it's actually gone
+    response = client.get(f"/items/{sample_item.id}")
+    assert response.status_code == 404
+
+
+def test_delete_item_rejected_when_unauthenticated(client, sample_item):
+    response = client.delete(f"/items/{sample_item.id}")
+
+    assert response.status_code in (401, 403)
+
+
+def test_create_item_rejects_more_than_4_images(client, auth_headers, master_data):
+    images = [{"image_data": "data:image/png;base64,iVBOR", "display_order": i} for i in range(5)]
+    response = client.post(
+        "/items/",
+        headers=auth_headers,
+        json={
+            "type": "found",
+            "title": "Dengan banyak foto",
+            "description": "Test",
+            "security_officer_id": master_data["security_officer"].id,
+            "images": images,
+        },
+    )
+
+    assert response.status_code == 400
+    assert "4 foto" in response.json()["detail"]

--- a/backend/tests/test_search_sanitization.py
+++ b/backend/tests/test_search_sanitization.py
@@ -1,59 +1,27 @@
-import os
-import unittest
+"""Tests for items search sanitization (SQL LIKE wildcard escaping).
 
-os.environ.setdefault("DATABASE_URL", "sqlite+pysqlite:///:memory:")
-os.environ.setdefault("SECRET_KEY", "test-secret-key")
-
-from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import StaticPool
-
-from app.database import Base, get_db
-from app.main import app
+Refactored from unittest.TestCase to pytest function style + fixtures
+per BE-5.1.
+"""
 
 
-class TestSearchSanitization(unittest.TestCase):
-    def setUp(self):
-        self.engine = create_engine(
-            "sqlite+pysqlite:///:memory:",
-            connect_args={"check_same_thread": False},
-            poolclass=StaticPool,
-        )
-        testing_session_local = sessionmaker(
-            autocommit=False,
-            autoflush=False,
-            bind=self.engine,
-        )
-        Base.metadata.create_all(bind=self.engine)
+def test_search_with_wildcards_is_escaped(client):
+    response = client.get("/items/?search=100%_guarantee")
 
-        def override_get_db():
-            db = testing_session_local()
-            try:
-                yield db
-            finally:
-                db.close()
-
-        app.dependency_overrides[get_db] = override_get_db
-        self.client = TestClient(app)
-
-    def tearDown(self):
-        app.dependency_overrides.clear()
-        Base.metadata.drop_all(bind=self.engine)
-        self.engine.dispose()
-
-    def test_search_with_wildcards_is_escaped(self):
-        response = self.client.get("/items/?search=100%_guarantee")
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIsInstance(response.json(), list)
-
-    def test_search_with_backslash_is_escaped(self):
-        response = self.client.get("/items/?search=some\\backslash")
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIsInstance(response.json(), list)
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_search_with_backslash_is_escaped(client):
+    response = client.get("/items/?search=some\\backslash")
+
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+
+def test_search_with_special_chars_does_not_crash(client):
+    """Composite test for various special characters in search input."""
+    for search_term in ["%%%", "___", "100%_special\\chars", "'; DROP TABLE items;--"]:
+        response = client.get(f"/items/?search={search_term}")
+        assert response.status_code == 200
+        assert isinstance(response.json(), list)

--- a/backend/tests/test_user_schema.py
+++ b/backend/tests/test_user_schema.py
@@ -1,43 +1,38 @@
-import os
-import unittest
+"""Schema verification: User table matches Temuin auth design.
 
-os.environ.setdefault("DATABASE_URL", "sqlite+pysqlite:///:memory:")
-os.environ.setdefault("SECRET_KEY", "test-secret-key")
+Refactored to pytest function style per BE-5.1.
+"""
 
-from sqlalchemy import create_engine, inspect
+from sqlalchemy import inspect
 
-from app.database import Base
 from app.models.user import User
 
 
-class UserSchemaTest(unittest.TestCase):
-    def setUp(self):
-        self.engine = create_engine("sqlite+pysqlite:///:memory:")
-        Base.metadata.create_all(bind=self.engine)
+def test_users_table_matches_temuin_auth_schema(engine):
+    inspector = inspect(engine)
+    columns = {column["name"]: column for column in inspector.get_columns("users")}
 
-    def tearDown(self):
-        Base.metadata.drop_all(bind=self.engine)
-        self.engine.dispose()
+    assert "id" in columns
+    assert columns["id"]["type"].__class__.__name__ in {"VARCHAR", "String"}
+    assert "firebase_uid" in columns
+    assert "password_hash" in columns
+    assert "role" in columns
+    assert "phone" in columns
+    assert columns["email"]["nullable"] is False
+    assert columns["name"]["nullable"] is False
+    assert columns["role"]["nullable"] is False
+    assert columns["firebase_uid"]["nullable"] is True
+    assert columns["password_hash"]["nullable"] is True
 
-    def test_users_table_matches_temuin_auth_schema(self):
-        inspector = inspect(self.engine)
-        columns = {column["name"]: column for column in inspector.get_columns("users")}
-
-        self.assertIn("id", columns)
-        self.assertIn(columns["id"]["type"].__class__.__name__, {"VARCHAR", "String"})
-        self.assertIn("firebase_uid", columns)
-        self.assertIn("password_hash", columns)
-        self.assertIn("role", columns)
-        self.assertIn("phone", columns)
-        self.assertFalse(columns["email"]["nullable"])
-        self.assertFalse(columns["name"]["nullable"])
-        self.assertFalse(columns["role"]["nullable"])
-        self.assertTrue(columns["firebase_uid"]["nullable"])
-        self.assertTrue(columns["password_hash"]["nullable"])
-
-        user_columns = {column.name for column in User.__table__.columns}
-        self.assertTrue({"id", "firebase_uid", "password_hash", "email", "name", "role", "phone", "created_at"}.issubset(user_columns))
-
-
-if __name__ == "__main__":
-    unittest.main()
+    user_columns = {column.name for column in User.__table__.columns}
+    expected = {
+        "id",
+        "firebase_uid",
+        "password_hash",
+        "email",
+        "name",
+        "role",
+        "phone",
+        "created_at",
+    }
+    assert expected.issubset(user_columns)


### PR DESCRIPTION
## Summary

Bundle implementasi **BE-5.1 + BE-5.2 + BE-5.4** Sprint 5 dalam satu PR. Refactor 5 file test backend dari `unittest.TestCase` ke pytest function style + fixtures, tambah HTTP-level test gap (`/me`, item CRUD, claim flow, unauthorized scenarios), dan setup `pytest-cov` dengan threshold ≥60% sesuai DEC-020.

## Verifikasi Lokal

```
============================== test session starts ===============================
51 passed, 3 warnings in 24.33s
---------- coverage: platform linux, python 3.12.13-final-0 ----------
TOTAL                             711    122    134     29  77.40%
Required test coverage of 60% reached. Total coverage: 77.40%
```

**51 tests passing, coverage 77.40% (target 60%)** — well above DEC-020 threshold.

## What Changed

### `backend/conftest.py` (BARU, 195 baris)

Pytest config + 9 reusable fixtures:
- `engine` — in-memory SQLite dengan StaticPool, schema fresh per test
- `db_session` — SQLAlchemy session
- `client` — `TestClient` dengan `get_db` override yang share session sama `db_session` fixture
- `auth_user` / `admin_user` / `superadmin_user` — pre-seeded user dengan bcrypt password
- `auth_headers` / `admin_headers` / `superadmin_headers` — bearer token JWT
- `master_data` — Category + Building + Location + SecurityOfficer (untuk item-related tests)
- `sample_item` — persisted Item type=found owned by `auth_user`

Helper `_bearer_for(user)` generate JWT token via `create_access_token` real (bukan mock), supaya test full integration pakai jalur yang sama dengan production code.

### `backend/pyproject.toml` (BARU, 53 baris)

- `[tool.pytest.ini_options]` — testpaths, addopts (`--cov=app --cov-report=term-missing --cov-report=xml --cov-fail-under=60`), markers (integration, slow), filterwarnings (suppress passlib + jose deprecation noise)
- `[tool.coverage.run]` — source=app, branch=true, omit (alembic, seed.py, config.py)
- `[tool.coverage.report]` — precision 2, exclude_lines (pragma, NotImplementedError, `if TYPE_CHECKING`)

### `backend/requirements.txt` (UPDATE)

Tambah `pytest-cov==6.0.0` (compatible dengan pytest 8.3.4 yang sudah ada).

### Test files (refactored + extended)

#### `backend/tests/test_auth_service.py` (`+108`/`-44`)
**Service-level** (existing, refactored):
- register: returns token, rejects non-itk email, rejects weak password, rejects password without digit (NEW), conflict on existing user with hash, set first password for legacy user
- login: valid credentials, unknown email, wrong password, legacy user without password

**HTTP-level** (BE-5.1 + BE-5.2):
- POST /auth/register: token returned, invalid email rejected
- POST /auth/login: token returned, wrong password rejected
- GET /auth/me: returns profile, missing token rejected, invalid token rejected
- PUT /auth/me: changes name+phone, persists to DB

#### `backend/tests/test_item_service.py` (`+248`/`-82`)
**Service-level** (refactored): owner update non-status, owner cannot update status, admin can update status

**HTTP-level CRUD** (BE-5.2): create found requires security_officer, create lost no requirement, create authenticated, create unauthenticated rejected, list returns array, list with search, list filter by type, detail, detail 404, /items/me only own, /items/me unauthorized, PUT title, PUT status denied for user role, PUT status allowed for admin, DELETE by owner, DELETE unauthenticated, create rejects > 4 images

#### `backend/tests/test_claim_service.py` (`+264`/`-150`)
**Service-level** (refactored): notification untuk owner+admins on create, notification on update status, skip duplicate notification ketika admin = item owner, skip self-notification

**HTTP-level claim flow** (BE-5.2): POST /claims/ returns 201 + persists, POST unauthorized, admin approve via PUT /claims/{id}/status (verify item status -> in_claim), GET /claims/me only own, GET /claims/me unauthorized

#### `backend/tests/test_search_sanitization.py` & `test_user_schema.py` (refactored ke pytest)

Simpler refactor — terima `client` / `engine` fixture langsung, hapus `setUp`/`tearDown`.

## Why This Way

- **Fixture style** memudahkan composition. Test claim flow tinggal terima `client`, `claim_setup`, dan `db_session` tanpa duplicate seeding logic
- **In-memory SQLite + StaticPool** karena PostgreSQL spec di prod butuh service container. SQLite cukup untuk test logic karena schema kompatibel (semua column types portable)
- **Coverage 77.40%** dapat dari menambahkan HTTP-level test untuk router code path yang sebelumnya zero coverage (auth router, items router, claims router)
- **JWT real, bukan mock** karena fungsi `create_access_token` sudah test-friendly (tidak butuh side effect external)

## Sprint Mapping

- BE-5.1 → fixture pytest + refactor 5 test file
- BE-5.2 → HTTP CRUD endpoints (create/list/detail/update/delete + /me + claim flow + unauthorized)
- BE-5.4 → pytest-cov + threshold 60% (achieved 77.40%)
- DEC-020 → coverage threshold

BE-5.3 (bug fix) tidak diperlukan — test refactor + extend tidak menemukan bug functional dari logic existing.

## How To Test

```bash
cd backend
pip install -r requirements.txt
pytest tests --cov=app --cov-report=term-missing --cov-fail-under=60
```

Atau via container:
```bash
docker run --rm --entrypoint="" -v ${PWD}/backend:/app -w /app temuin-backend:latest \
  sh -c "pip install -q pytest-cov==6.0.0 && pytest tests --cov=app --cov-fail-under=60"
```

Expected: 51 passed, coverage 77.40%.

## Notes

- CODEOWNERS lock `/backend/ → @disnejy`. Wajib approval dari BE Lead
- File ini menjadi foundation untuk Sprint 6 microservice testing — pattern fixture + TestClient + JWT helper bisa direplikasi di setiap service skeleton (auth-service, item-service, engagement-service)
- Draft PR — user / @disnejy yang mark ready for review
