### PR TITLE
docs(sprint): mark sprint-05 BE/FE/DO tasks as done after PR merges

### DIFF
--- a/temuin-docs/06-sprints/sprint-05.md
+++ b/temuin-docs/06-sprints/sprint-05.md
@@ -13,27 +13,27 @@ Menerapkan git workflow (branch protection, CODEOWNERS, Makefile), menambah test
 
 | ID | Task | Priority | Estimate | Depends On | Status | Branch/Ref | Notes |
 |----|------|----------|----------|------------|--------|------------|-------|
-| BE-5.1 | Buat fixture test backend dan auth tests | High | 3h | BE-4.3 | todo | - | Modul 10: pytest fixtures, conftest.py. Min 5 test (register, duplicate, login success, login wrong, /me) |
-| BE-5.2 | Tambah tests untuk items dan claims | High | 4h | BE-5.1 | todo | - | Modul 10: target min 12 backend tests total. Cover create, list, detail, claim flow, unauthorized |
-| BE-5.3 | Rapikan bug atau celah yang terungkap dari test backend | Medium | 2h | BE-5.2 | todo | - | - |
-| BE-5.4 | Setup pytest-cov dengan threshold ≥60% (DEC-020) | Medium | 2h | BE-5.1 | todo | - | Tambah `pytest --cov=app --cov-fail-under=60` ke CI. Conftest.py dengan fixture `client`, `db_session`, `auth_user` reusable |
+| BE-5.1 | Buat fixture test backend dan auth tests | High | 3h | BE-4.3 | done | feat/backend/sprint-05-tests-coverage | Modul 10: pytest fixtures, conftest.py. PR #92 merged. 51 tests pass, conftest.py dengan fixture client, db_session, auth_user, admin_user, superadmin_user |
+| BE-5.2 | Tambah tests untuk items dan claims | High | 4h | BE-5.1 | done | feat/backend/sprint-05-tests-coverage | Modul 10: 51 tests (target 12). Cover create, list, detail, claim flow create→approve, unauthorized. PR #92 merged |
+| BE-5.3 | Rapikan bug atau celah yang terungkap dari test backend | Medium | 2h | BE-5.2 | done | feat/backend/sprint-05-tests-coverage | Tidak ditemukan bug functional saat refactor + extend test. PR #92 merged |
+| BE-5.4 | Setup pytest-cov dengan threshold ≥60% (DEC-020) | Medium | 2h | BE-5.1 | done | feat/backend/sprint-05-tests-coverage | PR #92 merged. Coverage 77.40% (target 60%). pyproject.toml dengan --cov-fail-under=60 |
 
 ## Lead Frontend (@nicholasmnrng)
 
 | ID | Task | Priority | Estimate | Depends On | Status | Branch/Ref | Notes |
 |----|------|----------|----------|------------|--------|------------|-------|
-| FE-5.1 | Perbaiki bug frontend hasil sprint UTS | High | 3h | QA-4.3 | in_progress | feature/fe-5.1-bug-fixes | menunggu PR #86 merge ke master |
-| FE-5.2 | Tambah route lazy loading dan cleanup state yang perlu | Medium | 2h | FE-5.1 | in_progress | feature/fe-5.2-lazy-loading | PR #85 ditutup, gabung ke PR #86 |
-| FE-5.3 | Pastikan build frontend stabil untuk kebutuhan CI | Medium | 2h | FE-5.2 | in_progress | feature/fe-5.3-5.4-testing | PR #86 menunggu approval |
-| FE-5.4 | Setup Vitest dan tulis min 7 frontend tests | Medium | 3h | FE-5.3 | in_progress | feature/fe-5.3-5.4-testing | Modul 10: frontend testing dengan Vitest. Coverage 71% (target 40%) |
+| FE-5.1 | Perbaiki bug frontend hasil sprint UTS | High | 3h | QA-4.3 | done | feature/fe-5.3-5.4-testing | PR #86 merged (stacked dengan FE-5.2..5.4). PR #85 ditutup karena duplicated |
+| FE-5.2 | Tambah route lazy loading dan cleanup state yang perlu | Medium | 2h | FE-5.1 | done | feature/fe-5.3-5.4-testing | PR #86 merged (stacked) |
+| FE-5.3 | Pastikan build frontend stabil untuk kebutuhan CI | Medium | 2h | FE-5.2 | done | feature/fe-5.3-5.4-testing | PR #86 merged. Build hijau di CI |
+| FE-5.4 | Setup Vitest dan tulis min 7 frontend tests | Medium | 3h | FE-5.3 | done | feature/fe-5.3-5.4-testing | Modul 10: PR #86 merged. 21 tests (target 7) di 7 file. Coverage 71.08% (target 40%) di scope yang diuji. @vitest/coverage-v8 + threshold 40% di vite.config.js |
 
 ## Lead DevOps (@PangeranSilaen)
 
 | ID | Task | Priority | Estimate | Depends On | Status | Branch/Ref | Notes |
 |----|------|----------|----------|------------|--------|------------|-------|
-| DO-5.1 | Buat workflow CI 3-job (lint + backend-test + frontend-test) (DEC-020) | High | 3h | BE-5.1 | todo | - | Modul 10: `.github/workflows/ci.yml` dengan job paralel. Job `lint` (ruff backend + eslint frontend), `backend-test` (pytest cov ≥60%), `frontend-test` (vitest cov ≥40% + npm build) |
-| DO-5.2 | Tambah ruff config + integrasikan ke CI lint job | Medium | 1h | DO-5.1 | todo | - | `pyproject.toml` punya `[tool.ruff]`. `ruff check backend/` exit 0 di CI |
-| DO-5.3 | Tulis aturan review dan dokumentasikan branch protection di `docs/branch-protection-guide.md` | Medium | 1h | DO-5.1 | todo | - | Step-by-step screenshot setup branch protection + required status checks: `lint`, `backend-test`, `frontend-test`. Tidak perlu di-enable kalau tidak ada permission, cukup dokumentasikan |
+| DO-5.1 | Buat workflow CI 3-job (lint + backend-test + frontend-test) (DEC-020) | High | 3h | BE-5.1 | done | feat/devops/sprint-05-workflow-ci | Modul 10: PR #90 merged. `.github/workflows/ci.yml` dengan 3 job paralel (lint, backend-test, frontend-test). Bonus fix: eslint.config.js (reactHooks v5 compat) + step-level continue-on-error untuk bootstrap window |
+| DO-5.2 | Tambah ruff config + integrasikan ke CI lint job | Medium | 1h | DO-5.1 | done | feat/devops/sprint-05-ruff-config | PR #89 merged. Root pyproject.toml dengan [tool.ruff] target backend, line-length 100, rules E/W/F/I/B/UP/SIM. Makefile composite lint/test/coverage targets |
+| DO-5.3 | Tulis aturan review dan dokumentasikan branch protection di `docs/branch-protection-guide.md` | Medium | 1h | DO-5.1 | done | docs/devops/sprint-05-branch-protection-guide | PR #91 merged. docs/branch-protection-guide.md 246 baris, 7 section (konsep, status saat ini, setup ruleset, required status checks, verifikasi, troubleshooting, referensi) |
 | DO-5.4 | Setup branch protection rules di master | High | 1h | - | done | - | Modul 9: ruleset aktif, 1 approval required |
 | DO-5.5 | Buat CODEOWNERS file | Medium | 1h | - | done | chore/add-codeowners | Modul 9: PR #77 merged |
 | DO-5.6 | Buat docker-compose.prod.yml | Medium | 1h | - | done | feature/compose-profiles | Modul 9: PR #78 merged |


### PR DESCRIPTION
## Summary

Update status task Sprint 5 di `temuin-docs/06-sprints/sprint-05.md` ke `done` setelah 4 PR utama Sprint 5 sudah merge ke master:
- PR #89 (DO-5.2 ruff config)
- PR #90 (DO-5.1 CI workflow)
- PR #91 (DO-5.3 branch protection guide)
- PR #92 (BE-5.1 + BE-5.2 + BE-5.3 + BE-5.4 bundle)
- PR #86 (FE-5.1 + FE-5.2 + FE-5.3 + FE-5.4 stacked)

Per DEC-012: status `done` baru valid setelah merge ke master, jadi update ini benar saatnya sekarang.

## What Changed

Hanya 1 file: `temuin-docs/06-sprints/sprint-05.md`

### Backend (4 task)
- BE-5.1, BE-5.2, BE-5.3, BE-5.4: `todo` → `done`. Branch/Ref diisi `feat/backend/sprint-05-tests-coverage`. Notes diupdate dengan hasil aktual (51 tests, coverage 77.40%, dst)

### Frontend (4 task)
- FE-5.1, FE-5.2, FE-5.3, FE-5.4: `in_progress` → `done`. Branch/Ref diisi `feature/fe-5.3-5.4-testing`. Notes diupdate dengan info merge + hasil aktual (21 tests, coverage 71.08%)

### DevOps (3 task)
- DO-5.1, DO-5.2, DO-5.3: `todo` → `done`. Branch/Ref diisi sesuai branch yang merged. Notes diupdate dengan PR number
- DO-5.4, DO-5.5, DO-5.6, DO-5.7: tidak diubah, sudah `done` dari sebelumnya

### QA (TIDAK DIUBAH)
- QA-5.1, QA-5.2, QA-5.3: status tetap `todo`. Itu kerjaan @raniayudewi sendiri, bukan urusan PR ini

## Why This PR

Sesuai aturan `AGENTS.md` Task Tracking Rules:
- Status `done` hanya boleh dipakai setelah perubahan sudah di-commit dan di-push ke remote
- Setelah push (atau dalam case ini setelah merge), isi kolom `Branch/Ref` lalu ubah status ke `done`

PR ini adalah housekeeping pasca-merge. Tidak ada perubahan kode, hanya update dokumen status.

## Sprint Mapping

- Per DEC-012: status `done` valid karena semua PR sudah merged
- Branch/Ref kolom mengikuti branch name yang merged

## Notes

- File ini tidak kena CODEOWNERS lock spesifik (sprint-05.md di `temuin-docs/`). 1 approval cukup
- Draft PR — user yang mark ready for review
- Ini diff super kecil (+11/-11), 11 baris status diubah saja
