### PR TITLE
fix(frontend): hapus trailing slash di auth + master-data API call (307 prod blocker)

### DIFF
--- a/frontend/src/__tests__/LoginPage.test.jsx
+++ b/frontend/src/__tests__/LoginPage.test.jsx
@@ -35,6 +35,6 @@ describe('LoginPage Component', () => {
     
     fireEvent.click(screen.getByRole('button', { name: /masuk/i }))
     
-    expect(api.post).toHaveBeenCalledWith('/auth/login/', { email: 'test@student.itk.ac.id', password: 'wrongpass' })
+    expect(api.post).toHaveBeenCalledWith('/auth/login', { email: 'test@student.itk.ac.id', password: 'wrongpass' })
   })
 })

--- a/frontend/src/components/items/EditItemDialog.jsx
+++ b/frontend/src/components/items/EditItemDialog.jsx
@@ -51,10 +51,10 @@ export function EditItemDialog({ isOpen, onClose, item, onSuccess }) {
       setMasterDataError(null)
       
       const [catRes, buildRes, locRes, soRes] = await Promise.all([
-        api.get('/master-data/categories/', { signal }),
-        api.get('/master-data/buildings/', { signal }),
-        api.get('/master-data/locations/', { signal }),
-        api.get('/master-data/security-officers/', { signal }),
+        api.get('/master-data/categories', { signal }),
+        api.get('/master-data/buildings', { signal }),
+        api.get('/master-data/locations', { signal }),
+        api.get('/master-data/security-officers', { signal }),
       ])
       
       setCategories(catRes.data?.data || catRes.data || [])

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -19,7 +19,7 @@ export default function LoginPage() {
     e.preventDefault()
     try {
       setLoading(true)
-      const response = await api.post("/auth/login/", { email, password })
+      const response = await api.post("/auth/login", { email, password })
       const { access_token } = response.data
 
       // Simpan token dulu agar interceptor bisa pakai

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -42,7 +42,7 @@ export default function RegisterPage() {
 
     try {
       setLoading(true)
-      const response = await api.post("/auth/register/", { email, password, name })
+      const response = await api.post("/auth/register", { email, password, name })
       const { access_token } = response.data
 
       localStorage.setItem("internalToken", access_token)


### PR DESCRIPTION
## Production Blocker — 307 Redirect di Auth + Master Data

### Masalah

Setelah deploy monolith ke `https://temuin.pangeransilaen.net`, login/register gagal silent. Backend log:

```
POST /auth/register/ HTTP/1.1" 307 Temporary Redirect
POST /auth/login/    HTTP/1.1" 307 Temporary Redirect
```

### Root Cause

FastAPI `redirect_slashes=True` (default). Frontend kirim `/auth/login/` (trailing slash), backend definisikan `@router.post("/login")` tanpa slash → 307 redirect.

Browser/axios setelah 307 redirect bisa strip body atau jadi cross-origin issue (HTTPS → HTTP backend).

### Endpoint yang affected

| Frontend                          | Backend                       | Status sebelum |
| --------------------------------- | ----------------------------- | -------------- |
| `POST /auth/login/`                 | `POST /auth/login`              | ❌ 307         |
| `POST /auth/register/`              | `POST /auth/register`           | ❌ 307         |
| `GET /master-data/categories/`      | `GET /master-data/{entity}`     | ❌ 307         |
| `GET /master-data/buildings/`       | (idem)                        | ❌ 307         |
| `GET /master-data/locations/`       | (idem)                        | ❌ 307         |
| `GET /master-data/security-officers/` | (idem)                        | ❌ 307         |

Endpoint `/items/` dan `/claims/` (root collection dengan path `/`) sudah konsisten antara FE & BE. Tidak diubah.

### Fix

Hapus trailing slash di file FE:

- `frontend/src/pages/LoginPage.jsx`
- `frontend/src/pages/RegisterPage.jsx`
- `frontend/src/__tests__/LoginPage.test.jsx` (sync assertion)
- `frontend/src/components/items/EditItemDialog.jsx` (4 master-data GET)

### Verifikasi

**Local test**: `npm test --run` → 21/21 pass

**Production verify** (post deploy image baru `pangeransilaen/temuin-frontend:prod` digest `sha256:95b4c34589f1`):

```bash
$ curl -X POST -d '{"email":"deploy.test@student.itk.ac.id","password":"TestPass123!","name":"Deploy Test"}' \
    -H "Content-Type: application/json" \
    https://temuin.pangeransilaen.net/api/auth/register
{"access_token":"eyJhbGciOiJIUzI1NiIs...","token_type":"bearer"}

$ curl -X POST -d '{"email":"deploy.test@student.itk.ac.id","password":"TestPass123!"}' \
    -H "Content-Type: application/json" \
    https://temuin.pangeransilaen.net/api/auth/login
{"access_token":"eyJhbGciOiJIUzI1NiIs...","token_type":"bearer"}
```

Backend log:
```
POST /auth/register HTTP/1.1" 200 OK
POST /auth/login    HTTP/1.1" 200 OK
```

### Out of scope

Refactor FastAPI ke `redirect_slashes=False` atau standardize trailing slash convention di semua router → masuk Sprint 7+ kalau perlu. Untuk sekarang, fix minimal di FE udah cukup unblock production.

### Affected files

- `frontend/src/pages/LoginPage.jsx`
- `frontend/src/pages/RegisterPage.jsx`
- `frontend/src/__tests__/LoginPage.test.jsx`
- `frontend/src/components/items/EditItemDialog.jsx`
