### PR TITLE
fix(backend): exclude credential files dari Docker image (security leak)

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -7,6 +7,14 @@ venv/
 .env.local
 .env.docker
 
+# Cloud / service account credentials (NEVER bake into images!)
+serviceAccountKey*.json
+*-credentials.json
+*-service-account*.json
+firebase-*.json
+gcp-*.json
+aws-credentials*
+
 # Python cache
 __pycache__/
 *.pyc


### PR DESCRIPTION
## Security Fix: Service Account Key Leak in Docker Image

### Masalah

`backend/serviceAccountKey.json` (Firebase service account private key) ke-COPY ke Docker image karena tidak terdaftar di `backend/.dockerignore`. Image `pangeransilaen/temuin-backend:latest` adalah **public** di Docker Hub, jadi siapa pun bisa pull image dan extract credentials.

Confirmed leak:
```
$ docker run --rm pangeransilaen/temuin-backend:latest ls /app/
... serviceAccountKey.json  <-- 2384 chars, valid private key
```

### Sudah Dilakukan (di production)

1. **Firebase service account key sudah di-revoke** di GCP Console (oleh @PangeranSilaen)
2. **Backend image rebuilt** dengan `.dockerignore` patched
3. **Image latest pushed** dengan digest baru `sha256:ef893ed5d86666990e87660e9e6d25a1003c4db43cd20a3a68ad2c7669d2c07e`
4. **Container production recreate** di VPS, verified `/app/serviceAccountKey.json` no longer exists
5. **Health check production**: backend `(healthy)`, login/register masih work

### Yang Diubah

`backend/.dockerignore` — tambah pattern untuk berbagai credential file:

```
serviceAccountKey*.json
*-credentials.json
*-service-account*.json
firebase-*.json
gcp-*.json
aws-credentials*
```

### Catatan: Firebase Code Status

Backend tidak lagi pakai Firebase aktif sejak migrasi auth ke email-only (DEC-008).
Sisa-sisa Firebase di codebase:
- `backend/app/models/user.py:10`: `firebase_uid` column (nullable, dipertahankan untuk backward compat)
- `backend/alembic/versions/0001_initial_schema.py` & `0003_make_firebase_uid_nullable.py`: migration history (jangan dihapus, history tetap)

Cleanup dead `firebase_uid` column **tidak** dilakukan di PR ini untuk avoid konflik dengan PR #96 (microservices split, masih draft).

### Test

`pytest backend/` di CI akan run as usual. Tidak ada perubahan logic, hanya `.dockerignore`.
