### PR TITLE
chore(.gitignore): tambah credential patterns + superpowers folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,14 @@ temp/
 
 # Credentials (safety net)
 serviceAccountKey.json
+serviceAccountKey*.json
+*-credentials.json
+*-service-account*.json
+firebase-*.json
+gcp-*.json
+aws-credentials*
 
 # AI agent local files
 .opencode/
 .claude/
+docs/superpowers/


### PR DESCRIPTION
Companion ke PR #98 (backend/.dockerignore). Mirror pattern security ke root .gitignore sebagai safety net supaya credential file tidak masuk ke commit di future:

- `serviceAccountKey*.json` (existing `serviceAccountKey.json` saja, sekarang lebih lebar)
- `*-credentials.json`
- `*-service-account*.json`
- `firebase-*.json`
- `gcp-*.json`
- `aws-credentials*`

Plus tambah `docs/superpowers/` ke gitignore (folder artifact AI agent brainstorming/spec, lokal saja, tidak di-track repo).

No code changes, low risk.