### PR TITLE
fix(item-service): list items selalu kosong karena soft-delete filter salah

### DIFF
--- a/services/item-service/app/items/service.py
+++ b/services/item-service/app/items/service.py
@@ -58,7 +58,7 @@ def create_item(db: Session, user_id: str, item_data: ItemCreate):
 def get_items_by_user(db: Session, user_id: str):
     return db.query(Item).filter(
         Item.created_by == user_id,
-        Item.deleted_at is None
+        Item.deleted_at.is_(None)
     ).order_by(Item.created_at.desc()).all()
 
 def get_items(
@@ -72,7 +72,7 @@ def get_items(
     building_id: str | None = None,
     location_id: str | None = None
 ):
-    query = db.query(Item).filter(Item.deleted_at is None)
+    query = db.query(Item).filter(Item.deleted_at.is_(None))
 
     if search:
         escaped = search.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
@@ -92,7 +92,7 @@ def get_items(
     return query.offset(skip).limit(limit).all()
 
 def get_item(db: Session, item_id: str):
-    return db.query(Item).filter(Item.id == item_id, Item.deleted_at is None).first()
+    return db.query(Item).filter(Item.id == item_id, Item.deleted_at.is_(None)).first()
 
 def update_item(db: Session, item_id: str, user_id: str, user_role: str, item_data: ItemUpdate):
     item = get_item(db, item_id)

--- a/services/item-service/tests/test_items_soft_delete.py
+++ b/services/item-service/tests/test_items_soft_delete.py
@@ -1,0 +1,71 @@
+"""Regression test for soft-delete filter bug.
+
+Bug history: ruff E711 auto-fix mengubah `Item.deleted_at == None`
+menjadi `Item.deleted_at is None`. Pada SQLAlchemy filter, `is` operator
+tidak overloadable jadi expression, sehingga filter dievaluasi sebagai
+boolean `False` di Python. Akibatnya GET /items/ selalu mengembalikan [].
+
+Fix: gunakan `Item.deleted_at.is_(None)` untuk menghasilkan SQL
+`deleted_at IS NULL` yang benar.
+
+Test ini memvalidasi bahwa item baru muncul di list dan bisa diambil
+ulang via /items/{id} setelah create_item.
+"""
+
+
+def test_create_item_then_listed_and_fetchable(client, user_token):
+    """POST /items/ lalu GET /items/ harus mengembalikan item yang baru dibuat."""
+    payload = {
+        "type": "lost",
+        "title": "Regression Test Item",
+        "description": "Item ini harus muncul setelah dibuat.",
+        "images": [],
+    }
+    create_resp = client.post(
+        "/items/",
+        json=payload,
+        headers={"Authorization": f"Bearer {user_token}"},
+    )
+    assert create_resp.status_code == 200, create_resp.text
+    item_id = create_resp.json()["id"]
+
+    list_resp = client.get("/items/")
+    assert list_resp.status_code == 200
+    items = list_resp.json()
+    assert isinstance(items, list)
+    assert any(it["id"] == item_id for it in items), (
+        "Item baru tidak muncul di GET /items/. "
+        "Cek filter soft-delete (Item.deleted_at.is_(None) bukan `is None`)."
+    )
+
+    detail_resp = client.get(f"/items/{item_id}")
+    assert detail_resp.status_code == 200
+    assert detail_resp.json()["id"] == item_id
+
+
+def test_my_items_returns_user_owned_items(client, user_token):
+    """GET /items/me harus return item milik current user."""
+    payload = {
+        "type": "lost",
+        "title": "My Item",
+        "description": "Owned by user-uuid-1.",
+        "images": [],
+    }
+    create_resp = client.post(
+        "/items/",
+        json=payload,
+        headers={"Authorization": f"Bearer {user_token}"},
+    )
+    assert create_resp.status_code == 200
+    item_id = create_resp.json()["id"]
+
+    me_resp = client.get(
+        "/items/me",
+        headers={"Authorization": f"Bearer {user_token}"},
+    )
+    assert me_resp.status_code == 200
+    my_items = me_resp.json()
+    assert any(it["id"] == item_id for it in my_items), (
+        "Item milik user tidak muncul di /items/me. "
+        "Cek filter soft-delete di get_items_by_user."
+    )


### PR DESCRIPTION
## Bug
Setelah submit form Buat Laporan, toast `Laporan berhasil dibuat!` muncul tapi item tidak muncul di Daftar Barang.

Verifikasi via DB di VPS production:
- POST `/api/items/` -> 200 OK, row tersimpan di `item_db.items` (ada 2 row test).
- GET `/api/items/` -> `[]` walau ada 2 row aktif (status=open, deleted_at IS NULL).

## Root cause
Ruff E711 auto-fix di commit `ac4258b` mengubah:

```python
.filter(Item.deleted_at == None)   # benar untuk SQLAlchemy
.filter(Item.deleted_at is None)   # SALAH - Python bool, bukan SQL expr
```

Operator `is` di Python tidak bisa di-overload, jadi `Item.deleted_at is None` di-evaluate sebagai `False` saat parsing. Filter berubah jadi efektif `WHERE false` -> list selalu kosong.

3 lokasi terdampak di `services/item-service/app/items/service.py`:
- `get_items_by_user` (line 61)
- `get_items` (line 75)
- `get_item` (line 95)

## Fix
Ganti ke `Item.deleted_at.is_(None)` yang menghasilkan SQL `deleted_at IS NULL` sesuai SQLAlchemy idiom.

## Tests
Ditambah `services/item-service/tests/test_items_soft_delete.py`:
- `test_create_item_then_listed_and_fetchable` - POST lalu GET memastikan item muncul di list dan `GET /items/{id}`.
- `test_my_items_returns_user_owned_items` - `GET /items/me` return item yang baru dibuat.

Sudah diverifikasi kedua regression test gagal kalau fix di-revert (cek via revert sementara di lokal). Total item-service: 7/7 pass, ruff `services/` clean.

## Risk
- Scope sangat sempit: 3 baris query filter + 1 file test baru.
- Tidak ada DB migration.
- CD pipeline akan otomatis deploy `temuin-item-service:latest` ke VPS Tencent setelah merge ke master.

## Verification setelah merge
1. CD selesai deploy.
2. `GET /api/items/` di production return 2 row existing.
3. Manual smoke create laporan baru via UI -> muncul di list.

## Catatan
Hotfix urgent - user tidak bisa lihat laporan-nya sendiri walau create-nya jalan.
