### PR TITLE
feat(frontend): implement sprint 7 observability UI

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -2,6 +2,7 @@ import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
+import { defineConfig, globalIgnores } from 'eslint/config'
 
 // eslint-plugin-react-hooks v5 dropped `configs.flat.recommended` in favor
 // of `configs.recommended` (which already exports a flat-config block).
@@ -29,10 +30,6 @@ export default defineConfig([
         sourceType: 'module',
       },
     },
-    plugins: {
-      'react-hooks': reactHooks,
-      'react-refresh': reactRefresh,
-    },
     rules: {
       ...js.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
@@ -43,4 +40,4 @@ export default defineConfig([
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
     },
   },
-]
+])

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,14 +1,19 @@
 import { RouterProvider } from "react-router-dom"
 import { router } from "@/app/router"
 import { AuthProvider } from "@/app/providers"
+import AppErrorBoundary from "@/components/AppErrorBoundary"
+import ServiceErrorBanner from "@/components/ServiceErrorBanner"
 import { Toaster } from "@/components/ui/sonner"
 
 function App() {
   return (
-    <AuthProvider>
-      <RouterProvider router={router} />
-      <Toaster />
-    </AuthProvider>
+    <AppErrorBoundary>
+      <AuthProvider>
+        <ServiceErrorBanner />
+        <RouterProvider router={router} />
+        <Toaster />
+      </AuthProvider>
+    </AppErrorBoundary>
   )
 }
 

--- a/frontend/src/__tests__/ServiceErrorBanner.test.jsx
+++ b/frontend/src/__tests__/ServiceErrorBanner.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import ServiceErrorBanner from "@/components/ServiceErrorBanner"
+import { SERVICE_ERROR_EVENT } from "@/config/api"
+
+describe("ServiceErrorBanner", () => {
+  it("renders retry banner with correlation id from service error event", async () => {
+    render(<ServiceErrorBanner />)
+
+    window.dispatchEvent(new CustomEvent(SERVICE_ERROR_EVENT, {
+      detail: {
+        message: "Layanan sementara terganggu. Coba muat ulang halaman ini.",
+        correlationId: "trace-123",
+      },
+    }))
+
+    expect(await screen.findByText("Layanan sementara terganggu")).toBeInTheDocument()
+    expect(screen.getByText("Trace: trace-123")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/__tests__/ServiceErrorBanner.test.jsx
+++ b/frontend/src/__tests__/ServiceErrorBanner.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
 import ServiceErrorBanner from "@/components/ServiceErrorBanner"
 import { SERVICE_ERROR_EVENT } from "@/config/api"
@@ -17,5 +17,23 @@ describe("ServiceErrorBanner", () => {
     expect(await screen.findByText("Layanan sementara terganggu")).toBeInTheDocument()
     expect(screen.getByText("Trace: trace-123")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument()
+  })
+
+  it("dismisses the service error banner without reloading", async () => {
+    render(<ServiceErrorBanner />)
+
+    window.dispatchEvent(new CustomEvent(SERVICE_ERROR_EVENT, {
+      detail: {
+        message: "Layanan sementara terganggu. Coba muat ulang halaman ini.",
+      },
+    }))
+
+    expect(await screen.findByText("Layanan sementara terganggu")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Tutup banner gangguan layanan" }))
+
+    await waitFor(() => {
+      expect(screen.queryByText("Layanan sementara terganggu")).not.toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/__tests__/StatusPage.test.jsx
+++ b/frontend/src/__tests__/StatusPage.test.jsx
@@ -1,5 +1,5 @@
-import { render, screen, waitFor } from "@testing-library/react"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { act, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import StatusPage from "@/pages/StatusPage"
 import { api } from "@/config/api"
 
@@ -12,6 +12,10 @@ vi.mock("@/config/api", () => ({
 describe("StatusPage", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it("fetches service status from the public status endpoint", async () => {
@@ -33,6 +37,66 @@ describe("StatusPage", () => {
     expect(api.get).toHaveBeenCalledWith("/api/status", expect.objectContaining({
       signal: expect.any(AbortSignal),
     }))
+  })
+
+  it("shows degraded service status as non-success status", async () => {
+    api.get.mockResolvedValueOnce({
+      data: {
+        services: [
+          { name: "engagement", status: "degraded", latency_ms: 42 },
+        ],
+      },
+    })
+
+    render(<StatusPage />)
+
+    const degradedBadge = await screen.findByLabelText("Engagement Service degraded")
+    expect(degradedBadge).toBeInTheDocument()
+    expect(degradedBadge).toHaveTextContent("degraded")
+    expect(degradedBadge).not.toHaveClass("text-success")
+  })
+
+  it("polls status endpoint every 30 seconds", async () => {
+    vi.useFakeTimers()
+    api.get
+      .mockResolvedValueOnce({ data: { services: [] } })
+      .mockResolvedValueOnce({ data: { services: [] } })
+
+    render(<StatusPage />)
+
+    expect(api.get).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      vi.advanceTimersByTime(30000)
+      await Promise.resolve()
+    })
+
+    expect(api.get).toHaveBeenCalledTimes(2)
+  })
+
+  it("aborts active polling requests on unmount", async () => {
+    vi.useFakeTimers()
+    const signals = []
+    api.get.mockImplementation((_url, config) => {
+      signals.push(config.signal)
+      return new Promise(() => {})
+    })
+
+    const { unmount } = render(<StatusPage />)
+
+    expect(api.get).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      vi.advanceTimersByTime(30000)
+      await Promise.resolve()
+    })
+
+    expect(api.get).toHaveBeenCalledTimes(2)
+
+    unmount()
+
+    expect(signals).toHaveLength(2)
+    expect(signals.every((signal) => signal.aborted)).toBe(true)
   })
 
   it("shows an error banner when status endpoint fails", async () => {

--- a/frontend/src/__tests__/StatusPage.test.jsx
+++ b/frontend/src/__tests__/StatusPage.test.jsx
@@ -1,0 +1,48 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import StatusPage from "@/pages/StatusPage"
+import { api } from "@/config/api"
+
+vi.mock("@/config/api", () => ({
+  api: {
+    get: vi.fn(),
+  },
+}))
+
+describe("StatusPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("fetches service status from the public status endpoint", async () => {
+    api.get.mockResolvedValueOnce({
+      data: {
+        services: [
+          { name: "auth", status: "up", latency_ms: 12 },
+          { name: "item", status: "down", latency_ms: null },
+        ],
+      },
+    })
+
+    render(<StatusPage />)
+
+    expect(await screen.findByText("Auth Service")).toBeInTheDocument()
+    expect(screen.getByText("Item Service")).toBeInTheDocument()
+    expect(screen.getByLabelText("Auth Service up")).toBeInTheDocument()
+    expect(screen.getByLabelText("Item Service down")).toBeInTheDocument()
+    expect(api.get).toHaveBeenCalledWith("/api/status", expect.objectContaining({
+      signal: expect.any(AbortSignal),
+    }))
+  })
+
+  it("shows an error banner when status endpoint fails", async () => {
+    api.get.mockRejectedValueOnce(new Error("service unavailable"))
+
+    render(<StatusPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText("Status belum tersedia")).toBeInTheDocument()
+    })
+    expect(screen.getByText("Gagal memuat status layanan.")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/router.jsx
+++ b/frontend/src/app/router.jsx
@@ -1,5 +1,5 @@
 import { createBrowserRouter } from "react-router-dom"
-import { lazy, Suspense } from "react"
+import { createElement, lazy, Suspense } from "react"
 import RootLayout from "@/components/layout/RootLayout"
 import HomePage from "@/pages/HomePage"
 import LoginPage from "@/pages/LoginPage"
@@ -8,9 +8,9 @@ import ProtectedRoute from "@/components/auth/ProtectedRoute"
 import AdminRoute from "@/components/auth/AdminRoute"
 import PageState from "@/components/PageState"
 
-const Loadable = (Component) => (props) => (
+const Loadable = (PageComponent) => (props) => (
   <Suspense fallback={<PageState state="loading" loadingText="Memuat halaman..." />}>
-    <Component {...props} />
+    {createElement(PageComponent, props)}
   </Suspense>
 );
 
@@ -23,6 +23,7 @@ const NotificationsPage = Loadable(lazy(() => import("@/pages/NotificationsPage"
 const AdminClaimsPage = Loadable(lazy(() => import("@/pages/AdminClaimsPage")))
 const AdminClaimDetailPage = Loadable(lazy(() => import("@/pages/AdminClaimDetailPage")))
 const AdminMasterDataPage = Loadable(lazy(() => import("@/pages/AdminMasterDataPage")))
+const StatusPage = Loadable(lazy(() => import("@/pages/StatusPage")))
 
 export const router = createBrowserRouter([
   {
@@ -32,6 +33,10 @@ export const router = createBrowserRouter([
   {
     path: "/register",
     element: <RegisterPage />,
+  },
+  {
+    path: "/status",
+    element: <StatusPage />,
   },
   {
     path: "/",

--- a/frontend/src/components/AppErrorBoundary.jsx
+++ b/frontend/src/components/AppErrorBoundary.jsx
@@ -1,0 +1,46 @@
+import { Component } from "react"
+import { RotateCcw } from "lucide-react"
+import { Alert, AlertAction, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+
+export default class AppErrorBoundary extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error, info) {
+    console.error("Unhandled frontend error:", error, info)
+  }
+
+  handleRefresh = () => {
+    window.location.reload()
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <main className="mx-auto flex min-h-screen max-w-2xl items-center px-4">
+          <Alert variant="destructive">
+            <AlertTitle>Halaman gagal dimuat</AlertTitle>
+            <AlertDescription>
+              Terjadi kesalahan pada tampilan. Muat ulang halaman untuk mencoba lagi.
+            </AlertDescription>
+            <AlertAction>
+              <Button variant="outline" size="sm" onClick={this.handleRefresh}>
+                <RotateCcw data-icon="inline-start" />
+                Refresh
+              </Button>
+            </AlertAction>
+          </Alert>
+        </main>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/frontend/src/components/ServiceErrorBanner.jsx
+++ b/frontend/src/components/ServiceErrorBanner.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { RotateCcw } from "lucide-react"
+import { RotateCcw, X } from "lucide-react"
 import { SERVICE_ERROR_EVENT } from "@/config/api"
 import { Alert, AlertAction, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
@@ -34,10 +34,20 @@ export default function ServiceErrorBanner() {
             )}
           </AlertDescription>
           <AlertAction>
-            <Button variant="outline" size="sm" onClick={handleRetry}>
-              <RotateCcw data-icon="inline-start" />
-              Retry
-            </Button>
+            <div className="flex gap-2">
+              <Button variant="outline" size="sm" onClick={handleRetry}>
+                <RotateCcw data-icon="inline-start" />
+                Retry
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setError(null)}
+                aria-label="Tutup banner gangguan layanan"
+              >
+                <X />
+              </Button>
+            </div>
           </AlertAction>
         </Alert>
       </div>

--- a/frontend/src/components/ServiceErrorBanner.jsx
+++ b/frontend/src/components/ServiceErrorBanner.jsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react"
+import { RotateCcw } from "lucide-react"
+import { SERVICE_ERROR_EVENT } from "@/config/api"
+import { Alert, AlertAction, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+
+export default function ServiceErrorBanner() {
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    const handleServiceError = (event) => setError(event.detail)
+    window.addEventListener(SERVICE_ERROR_EVENT, handleServiceError)
+
+    return () => window.removeEventListener(SERVICE_ERROR_EVENT, handleServiceError)
+  }, [])
+
+  if (!error) return null
+
+  const handleRetry = () => {
+    window.location.reload()
+  }
+
+  return (
+    <div className="border-b bg-background px-4 py-3">
+      <div className="mx-auto max-w-5xl">
+        <Alert variant="destructive">
+          <AlertTitle>Layanan sementara terganggu</AlertTitle>
+          <AlertDescription>
+            {error.message}
+            {error.correlationId && (
+              <span className="mt-1 block font-mono text-xs">
+                Trace: {error.correlationId}
+              </span>
+            )}
+          </AlertDescription>
+          <AlertAction>
+            <Button variant="outline" size="sm" onClick={handleRetry}>
+              <RotateCcw data-icon="inline-start" />
+              Retry
+            </Button>
+          </AlertAction>
+        </Alert>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/badge.jsx
+++ b/frontend/src/components/ui/badge.jsx
@@ -15,6 +15,8 @@ const badgeVariants = cva(
           "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
         destructive:
           "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        success:
+          "bg-success/10 text-success focus-visible:ring-success/20 dark:bg-success/20 dark:focus-visible:ring-success/40 [a]:hover:bg-success/20",
         outline:
           "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
         ghost:

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -1,6 +1,13 @@
 import axios from 'axios';
 import { toast } from 'sonner';
 
+const SERVICE_ERROR_EVENT = 'temuin:service-error';
+
+const notifyServiceError = (detail) => {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(SERVICE_ERROR_EVENT, { detail }));
+};
+
 /**
  * Centralized axios instance untuk Temuin frontend.
  *
@@ -24,6 +31,8 @@ export const api = axios.create({
   },
 });
 
+export { SERVICE_ERROR_EVENT };
+
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem('internalToken');
   if (token) {
@@ -36,12 +45,31 @@ api.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response) {
-      const { status } = error.response;
+      const { status, headers } = error.response;
+      const correlationId = headers?.['x-correlation-id'] || headers?.['X-Correlation-ID'];
+
+      if (status >= 500 && correlationId) {
+        console.error(`X-Correlation-ID: ${correlationId}`);
+      }
+
+      if (status === 429) {
+        toast.error('Terlalu banyak permintaan, coba lagi sebentar lagi');
+      }
+
       if (status === 503 || status === 504) {
         toast.error('Layanan sementara terganggu, coba lagi');
+        notifyServiceError({
+          status,
+          correlationId,
+          message: 'Layanan sementara terganggu. Coba muat ulang halaman ini.',
+        });
       }
     } else if (error.request) {
       toast.error('Layanan sementara terganggu, coba lagi');
+      notifyServiceError({
+        status: 'network',
+        message: 'Layanan sementara terganggu. Coba muat ulang halaman ini.',
+      });
     }
     return Promise.reject(error);
   }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -77,6 +77,7 @@
   --color-ring: var(--ring);
   --color-input: var(--input);
   --color-border: var(--border);
+  --color-success: var(--success);
   --color-destructive: var(--destructive);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
@@ -117,6 +118,7 @@
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
+  --success: oklch(0.45 0.14 150);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
@@ -152,6 +154,7 @@
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
+  --success: oklch(0.72 0.16 150);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);

--- a/frontend/src/pages/AdminClaimDetailPage.jsx
+++ b/frontend/src/pages/AdminClaimDetailPage.jsx
@@ -3,6 +3,7 @@ import { useParams, Link, useNavigate } from "react-router-dom"
 import { api } from "@/config/api"
 import { Button, buttonVariants } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle, CardFooter } from "@/components/ui/card"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { StatusBadge } from "@/components/ui/StatusBadge"
 import PageState from "@/components/PageState"
 import { toast } from "sonner"
@@ -16,6 +17,7 @@ export default function AdminClaimDetailPage() {
   
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+  const [actionError, setActionError] = useState(null)
   const [updating, setUpdating] = useState(false)
 
   const fetchData = async (signal) => {
@@ -56,6 +58,7 @@ export default function AdminClaimDetailPage() {
   const handleStatusUpdate = async (newStatus) => {
     try {
       setUpdating(true)
+      setActionError(null)
       await api.put(`/api/claims/${id}/status`, { status: newStatus })
       
       const statusLabel = {
@@ -71,6 +74,7 @@ export default function AdminClaimDetailPage() {
     } catch (error) {
       console.error("Error updating claim:", error)
       const errorMsg = error.response?.data?.detail || "Gagal mengubah status klaim."
+      setActionError(errorMsg)
       toast.error(errorMsg)
     } finally {
       setUpdating(false)
@@ -78,7 +82,7 @@ export default function AdminClaimDetailPage() {
   }
 
   if (loading) return <PageState state="loading" loadingText="Memuat detail klaim..." />
-  if (error) return <PageState state="error" errorText={error} onRetry={fetchData} />
+  if (error) return <PageState state="error" errorText={error} onRetry={() => fetchData()} />
   if (!claim) return <PageState state="empty" emptyText="Klaim tidak ditemukan." />
 
   return (
@@ -124,20 +128,27 @@ export default function AdminClaimDetailPage() {
           </div>
         </CardContent>
         <CardFooter className="flex flex-wrap gap-3 border-t pt-6">
+          {actionError && (
+            <Alert variant="destructive" className="basis-full">
+              <AlertTitle>Gagal memperbarui status</AlertTitle>
+              <AlertDescription>{actionError}</AlertDescription>
+            </Alert>
+          )}
+
           {claim.status === 'pending' && (
             <>
               <Button 
                 onClick={() => handleStatusUpdate('approved')} 
                 disabled={updating}
               >
-                Setujui Klaim
+                {updating ? "Memproses..." : "Setujui Klaim"}
               </Button>
               <Button 
                 variant="destructive" 
                 onClick={() => handleStatusUpdate('rejected')}
                 disabled={updating}
               >
-                Tolak Klaim
+                {updating ? "Memproses..." : "Tolak Klaim"}
               </Button>
             </>
           )}
@@ -148,14 +159,14 @@ export default function AdminClaimDetailPage() {
                 onClick={() => handleStatusUpdate('completed')}
                 disabled={updating}
               >
-                Tandai Selesai (Diserahkan)
+                {updating ? "Memproses..." : "Tandai Selesai (Diserahkan)"}
               </Button>
               <Button 
                 variant="outline" 
                 onClick={() => handleStatusUpdate('cancelled')}
                 disabled={updating}
               >
-                Batalkan Persetujuan
+                {updating ? "Memproses..." : "Batalkan Persetujuan"}
               </Button>
             </>
           )}

--- a/frontend/src/pages/AdminMasterDataPage.jsx
+++ b/frontend/src/pages/AdminMasterDataPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react"
 import { api } from "@/config/api"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
@@ -24,6 +25,8 @@ function MasterDataTable({ entityType, label, singular }) {
   const [editItem, setEditItem] = useState(null)
   const [name, setName] = useState("")
   const [saving, setSaving] = useState(false)
+  const [deletingId, setDeletingId] = useState(null)
+  const [actionError, setActionError] = useState(null)
 
   const fetchItems = async (signal) => {
     try {
@@ -51,12 +54,14 @@ function MasterDataTable({ entityType, label, singular }) {
   const openCreate = () => {
     setEditItem(null)
     setName("")
+    setActionError(null)
     setDialogOpen(true)
   }
 
   const openEdit = (item) => {
     setEditItem(item)
     setName(item.name)
+    setActionError(null)
     setDialogOpen(true)
   }
 
@@ -67,6 +72,7 @@ function MasterDataTable({ entityType, label, singular }) {
     }
     try {
       setSaving(true)
+      setActionError(null)
       if (editItem) {
         await api.put(`/api/master-data/${entityType}/${editItem.id}`, { name: name.trim() })
         toast.success(`${singular} berhasil diperbarui.`)
@@ -81,6 +87,7 @@ function MasterDataTable({ entityType, label, singular }) {
     } catch (err) {
       console.error("Error saving:", err)
       const errorMsg = err.response?.data?.detail || "Gagal menyimpan data."
+      setActionError(errorMsg)
       toast.error(errorMsg)
     } finally {
       setSaving(false)
@@ -90,18 +97,23 @@ function MasterDataTable({ entityType, label, singular }) {
   const handleDelete = async (item) => {
     if (!confirm(`Hapus ${singular.toLowerCase()} "${item.name}"?`)) return
     try {
+      setDeletingId(item.id)
+      setActionError(null)
       await api.delete(`/api/master-data/${entityType}/${item.id}`)
       toast.success(`${singular} berhasil dihapus.`)
       fetchItems()
     } catch (err) {
       console.error("Error deleting:", err)
       const errorMsg = err.response?.data?.detail || "Gagal menghapus data."
+      setActionError(errorMsg)
       toast.error(errorMsg)
+    } finally {
+      setDeletingId(null)
     }
   }
 
   if (loading) return <PageState state="loading" loadingText={`Memuat data ${label.toLowerCase()}...`} />
-  if (error) return <PageState state="error" errorText={error} onRetry={fetchItems} />
+  if (error) return <PageState state="error" errorText={error} onRetry={() => fetchItems()} />
 
   return (
     <div className="space-y-4">
@@ -112,6 +124,13 @@ function MasterDataTable({ entityType, label, singular }) {
         </Button>
       </div>
 
+      {actionError && (
+        <Alert variant="destructive">
+          <AlertTitle>Aksi admin gagal</AlertTitle>
+          <AlertDescription>{actionError}</AlertDescription>
+        </Alert>
+      )}
+
       {items.length === 0 ? (
         <PageState state="empty" emptyText={`Belum ada ${label.toLowerCase()} yang terdaftar.`} />
       ) : (
@@ -120,11 +139,11 @@ function MasterDataTable({ entityType, label, singular }) {
             <div key={item.id} className="flex items-center justify-between p-4 bg-card">
               <span className="font-medium text-sm">{item.name}</span>
               <div className="flex gap-2">
-                <Button variant="outline" size="sm" onClick={() => openEdit(item)}>
+                <Button variant="outline" size="sm" onClick={() => openEdit(item)} disabled={deletingId === item.id}>
                   Edit
                 </Button>
-                <Button variant="destructive" size="sm" onClick={() => handleDelete(item)}>
-                  Hapus
+                <Button variant="destructive" size="sm" onClick={() => handleDelete(item)} disabled={deletingId === item.id}>
+                  {deletingId === item.id ? "Menghapus..." : "Hapus"}
                 </Button>
               </div>
             </div>
@@ -140,6 +159,12 @@ function MasterDataTable({ entityType, label, singular }) {
               {editItem ? `Ubah nama ${singular.toLowerCase()} ini.` : `Masukkan nama ${singular.toLowerCase()} baru.`}
             </DialogDescription>
           </DialogHeader>
+          {actionError && (
+            <Alert variant="destructive">
+              <AlertTitle>Gagal menyimpan data</AlertTitle>
+              <AlertDescription>{actionError}</AlertDescription>
+            </Alert>
+          )}
           <div className="space-y-4 py-4">
             <div className="space-y-2">
               <Label htmlFor="name">Nama</Label>

--- a/frontend/src/pages/StatusPage.jsx
+++ b/frontend/src/pages/StatusPage.jsx
@@ -31,7 +31,11 @@ const serviceLabel = {
 
 function StatusBadge({ status, name }) {
   const normalized = normalizeStatus(status)
-  const variant = normalized === "down" ? "destructive" : "success"
+  const variant = {
+    up: "success",
+    degraded: "secondary",
+    down: "destructive",
+  }[normalized]
 
   return (
     <Badge
@@ -84,15 +88,21 @@ export default function StatusPage() {
 
   useEffect(() => {
     const controller = new AbortController()
+    const pollingControllers = new Set()
     fetchStatus(controller.signal)
 
     const interval = window.setInterval(() => {
       const pollingController = new AbortController()
-      fetchStatus(pollingController.signal)
+      pollingControllers.add(pollingController)
+      fetchStatus(pollingController.signal).finally(() => {
+        pollingControllers.delete(pollingController)
+      })
     }, POLLING_INTERVAL_MS)
 
     return () => {
       controller.abort()
+      pollingControllers.forEach((pollingController) => pollingController.abort())
+      pollingControllers.clear()
       window.clearInterval(interval)
     }
   }, [fetchStatus])

--- a/frontend/src/pages/StatusPage.jsx
+++ b/frontend/src/pages/StatusPage.jsx
@@ -1,0 +1,166 @@
+import { useCallback, useEffect, useState } from "react"
+import { RefreshCw } from "lucide-react"
+import { api } from "@/config/api"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+
+const POLLING_INTERVAL_MS = 30000
+
+const normalizeStatus = (status) => {
+  const value = String(status || "").toLowerCase()
+  if (["up", "healthy", "ok"].includes(value)) return "up"
+  if (["degraded", "partial"].includes(value)) return "degraded"
+  return "down"
+}
+
+const statusLabel = {
+  up: "up",
+  degraded: "degraded",
+  down: "down",
+}
+
+const serviceLabel = {
+  auth: "Auth Service",
+  item: "Item Service",
+  items: "Item Service",
+  engagement: "Engagement Service",
+}
+
+function StatusBadge({ status, name }) {
+  const normalized = normalizeStatus(status)
+  const variant = normalized === "down" ? "destructive" : "success"
+
+  return (
+    <Badge
+      variant={variant}
+      aria-label={`${name} ${statusLabel[normalized]}`}
+    >
+      {statusLabel[normalized]}
+    </Badge>
+  )
+}
+
+function StatusSkeleton() {
+  return (
+    <div className="grid gap-4 md:grid-cols-3">
+      {[0, 1, 2].map((item) => (
+        <Card key={item}>
+          <CardHeader>
+            <Skeleton className="h-5 w-32" />
+            <Skeleton className="h-4 w-24" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-4 w-28" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}
+
+export default function StatusPage() {
+  const [services, setServices] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [lastUpdated, setLastUpdated] = useState(null)
+
+  const fetchStatus = useCallback(async (signal) => {
+    try {
+      setError(null)
+      const response = await api.get("/api/status", { signal })
+      const statusData = response.data?.services || []
+      setServices(Array.isArray(statusData) ? statusData : [])
+      setLastUpdated(new Date())
+    } catch (err) {
+      if (err.name === "CanceledError" || err.code === "ERR_CANCELED") return
+      setError("Gagal memuat status layanan.")
+    } finally {
+      if (!signal?.aborted) setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    fetchStatus(controller.signal)
+
+    const interval = window.setInterval(() => {
+      const pollingController = new AbortController()
+      fetchStatus(pollingController.signal)
+    }, POLLING_INTERVAL_MS)
+
+    return () => {
+      controller.abort()
+      window.clearInterval(interval)
+    }
+  }, [fetchStatus])
+
+  const handleRefresh = () => {
+    setLoading(true)
+    fetchStatus()
+  }
+
+  return (
+    <main className="min-h-screen bg-background">
+      <div className="mx-auto flex max-w-5xl flex-col gap-6 px-4 py-8">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">Status Layanan</h1>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Monitoring kesehatan service Temuin.
+            </p>
+          </div>
+          <Button variant="outline" onClick={handleRefresh} disabled={loading}>
+            <RefreshCw data-icon="inline-start" />
+            Refresh
+          </Button>
+        </header>
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertTitle>Status belum tersedia</AlertTitle>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        <section role="status" aria-live="polite" className="flex flex-col gap-4">
+          {loading && services.length === 0 ? (
+            <StatusSkeleton />
+          ) : (
+            <div className="grid gap-4 md:grid-cols-3">
+              {services.map((service) => {
+                const name = serviceLabel[service.name] || service.name
+                return (
+                  <Card key={service.name}>
+                    <CardHeader>
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <CardTitle>{name}</CardTitle>
+                          <CardDescription>{service.name}</CardDescription>
+                        </div>
+                        <StatusBadge status={service.status} name={name} />
+                      </div>
+                    </CardHeader>
+                    <CardContent>
+                      <p className="text-sm text-muted-foreground">
+                        Latensi: {service.latency_ms ?? "-"} ms
+                      </p>
+                    </CardContent>
+                  </Card>
+                )
+              })}
+            </div>
+          )}
+        </section>
+
+        {lastUpdated && (
+          <p className="text-sm text-muted-foreground">
+            Terakhir diperbarui {lastUpdated.toLocaleTimeString("id-ID")}. Polling setiap 30 detik.
+          </p>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/temuin-docs/06-sprints/sprint-07.md
+++ b/temuin-docs/06-sprints/sprint-07.md
@@ -27,11 +27,11 @@
 
 | ID | Task | Priority | Estimate | Depends On | Status | Branch/Ref | Notes |
 |----|------|----------|----------|------------|--------|------------|-------|
-| FE-7.1 | Pastikan frontend forward via gateway path (sudah dari Sprint 6, verify kembali) | High | 1h | DO-7.2, BE-7.1 | todo | - | Verifikasi tidak ada hardcoded port service backend |
-| FE-7.2 | Tambah error boundary + banner shadcn `<Alert variant="destructive">` dengan Retry saat 503 | Medium | 2h | FE-7.1 | todo | - | Modul 13: graceful degradation UI |
-| FE-7.3 | Tambah feedback status untuk admin (loading state, success toast, error banner) | Medium | 2h | FE-7.2, BE-7.2 | todo | - | Konsistensi UX area admin |
-| FE-7.4 | Buat `StatusPage.jsx` dengan shadcn `<Card>` + `<Badge>` (success/destructive) + `<Skeleton>` (DEC-022) | Medium | 4h | BE-7.8, FE-7.2 | todo | - | Modul 14: route `/status`, polling 30 detik, public no-auth, source data `GET /api/status`. Accessibility: `role="status"`, `aria-label` per badge, target Lighthouse a11y ≥90 |
-| FE-7.5 | Update axios interceptor: log header `X-Correlation-ID` ke console saat 5xx error | Low | 1h | FE-7.4 | todo | - | Modul 14: debugging trace |
+| FE-7.1 | Pastikan frontend forward via gateway path (sudah dari Sprint 6, verify kembali) | High | 1h | DO-7.2, BE-7.1 | in_progress | - | Verifikasi tidak ada hardcoded port service backend |
+| FE-7.2 | Tambah error boundary + banner shadcn `<Alert variant="destructive">` dengan Retry saat 503 | Medium | 2h | FE-7.1 | in_progress | - | Modul 13: graceful degradation UI |
+| FE-7.3 | Tambah feedback status untuk admin (loading state, success toast, error banner) | Medium | 2h | FE-7.2, BE-7.2 | in_progress | - | Konsistensi UX area admin |
+| FE-7.4 | Buat `StatusPage.jsx` dengan shadcn `<Card>` + `<Badge>` (success/destructive) + `<Skeleton>` (DEC-022) | Medium | 4h | BE-7.8, FE-7.2 | in_progress | - | Modul 14: route `/status`, polling 30 detik, public no-auth, source data `GET /api/status`. Accessibility: `role="status"`, `aria-label` per badge, target Lighthouse a11y ≥90 |
+| FE-7.5 | Update axios interceptor: log header `X-Correlation-ID` ke console saat 5xx error | Low | 1h | FE-7.4 | in_progress | - | Modul 14: debugging trace |
 
 ## Lead DevOps (@PangeranSilaen)
 

--- a/temuin-docs/06-sprints/sprint-07.md
+++ b/temuin-docs/06-sprints/sprint-07.md
@@ -27,11 +27,11 @@
 
 | ID | Task | Priority | Estimate | Depends On | Status | Branch/Ref | Notes |
 |----|------|----------|----------|------------|--------|------------|-------|
-| FE-7.1 | Pastikan frontend forward via gateway path (sudah dari Sprint 6, verify kembali) | High | 1h | DO-7.2, BE-7.1 | in_progress | - | Verifikasi tidak ada hardcoded port service backend |
-| FE-7.2 | Tambah error boundary + banner shadcn `<Alert variant="destructive">` dengan Retry saat 503 | Medium | 2h | FE-7.1 | in_progress | - | Modul 13: graceful degradation UI |
-| FE-7.3 | Tambah feedback status untuk admin (loading state, success toast, error banner) | Medium | 2h | FE-7.2, BE-7.2 | in_progress | - | Konsistensi UX area admin |
-| FE-7.4 | Buat `StatusPage.jsx` dengan shadcn `<Card>` + `<Badge>` (success/destructive) + `<Skeleton>` (DEC-022) | Medium | 4h | BE-7.8, FE-7.2 | in_progress | - | Modul 14: route `/status`, polling 30 detik, public no-auth, source data `GET /api/status`. Accessibility: `role="status"`, `aria-label` per badge, target Lighthouse a11y ≥90 |
-| FE-7.5 | Update axios interceptor: log header `X-Correlation-ID` ke console saat 5xx error | Low | 1h | FE-7.4 | in_progress | - | Modul 14: debugging trace |
+| FE-7.1 | Pastikan frontend forward via gateway path (sudah dari Sprint 6, verify kembali) | High | 1h | DO-7.2, BE-7.1 | done | feature/frontend/sprint-07-observability-ui / PR #110 | Verifikasi tidak ada hardcoded port service backend |
+| FE-7.2 | Tambah error boundary + banner shadcn `<Alert variant="destructive">` dengan Retry saat 503 | Medium | 2h | FE-7.1 | done | feature/frontend/sprint-07-observability-ui / PR #110 | Modul 13: graceful degradation UI |
+| FE-7.3 | Tambah feedback status untuk admin (loading state, success toast, error banner) | Medium | 2h | FE-7.2, BE-7.2 | done | feature/frontend/sprint-07-observability-ui / PR #110 | Konsistensi UX area admin |
+| FE-7.4 | Buat `StatusPage.jsx` dengan shadcn `<Card>` + `<Badge>` (success/destructive) + `<Skeleton>` (DEC-022) | Medium | 4h | BE-7.8, FE-7.2 | done | feature/frontend/sprint-07-observability-ui / PR #110 | Modul 14: route `/status`, polling 30 detik, public no-auth, source data `GET /api/status`. Accessibility: `role="status"`, `aria-label` per badge, target Lighthouse a11y ≥90 |
+| FE-7.5 | Update axios interceptor: log header `X-Correlation-ID` ke console saat 5xx error | Low | 1h | FE-7.4 | done | feature/frontend/sprint-07-observability-ui / PR #110 | Modul 14: debugging trace |
 
 ## Lead DevOps (@PangeranSilaen)
 


### PR DESCRIPTION
## Ringkasan

Implementasi Lead Frontend Sprint 7 untuk production gateway observability dan reliability UI.

## Task Sprint 7

- FE-7.1: Verifikasi frontend tetap forward via gateway path `/api/*` tanpa hardcoded service port runtime.
- FE-7.2: Tambah global error boundary dan banner shadcn Alert destructive dengan tombol Retry untuk 503/504/network error.
- FE-7.3: Tambah feedback admin berupa loading state, success toast, dan error banner inline.
- FE-7.4: Tambah route public `/status` dengan `StatusPage.jsx`, polling 30 detik ke `GET /api/status`, shadcn Card/Badge/Skeleton, `role="status"`, dan `aria-label` badge.
- FE-7.5: Update axios interceptor untuk log `X-Correlation-ID` saat error 5xx.

## Verifikasi

- [x] `npm.cmd run test:run` -> 9 files passed, 24 tests passed
- [x] `npm.cmd run build` -> success
- [x] `npm.cmd run lint` -> 0 errors, 1 existing fast-refresh warning di router
- [x] `GET http://127.0.0.1:5173/status` -> 200 OK

## Catatan

`GET /api/status` membutuhkan dependency backend BE-7.8 agar StatusPage menampilkan data service nyata. Saat ini UI sudah siap dan akan menampilkan error state jika endpoint belum tersedia.
