### PR TITLE
feat(backend): Sprint 8 Backend Implementation - Security Hardening & Cleanup

### DIFF
--- a/services/auth-service/app/auth/router.py
+++ b/services/auth-service/app/auth/router.py
@@ -45,7 +45,7 @@ def update_me(update_data: UserUpdate, db: Session = Depends(get_db), current_us
     db.refresh(current_user)
     return current_user
 
-@router.get("/users/admins", response_model=list[UserResponse])
+@router.get("/users/admins", response_model=list[UserResponse], include_in_schema=False)
 def get_admins(
     db: Session = Depends(get_db),
     _: User = Depends(get_current_user),
@@ -59,7 +59,7 @@ def get_admins(
     admins = db.query(User).filter(User.role.in_(["admin", "superadmin"])).all()
     return admins
 
-@router.get("/users/{user_id}", response_model=UserResponse)
+@router.get("/users/{user_id}", response_model=UserResponse, include_in_schema=False)
 def get_user_by_id(
     user_id: str,
     db: Session = Depends(get_db),

--- a/services/auth-service/app/auth/schemas.py
+++ b/services/auth-service/app/auth/schemas.py
@@ -1,6 +1,7 @@
 import re
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class RegisterRequest(BaseModel):

--- a/services/auth-service/app/auth/schemas.py
+++ b/services/auth-service/app/auth/schemas.py
@@ -1,17 +1,49 @@
+import re
 from datetime import datetime
-
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class RegisterRequest(BaseModel):
     email: str
     password: str
-    name: str = Field(..., min_length=1)
+    name: str
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, v: str) -> str:
+        email_regex = re.compile(r"^[a-zA-Z0-9_.+-]+@([a-zA-Z0-9-]+\.)*itk\.ac\.id$", re.IGNORECASE)
+        if not email_regex.match(v):
+            raise ValueError("Hanya email dengan domain itk.ac.id yang diperbolehkan")
+        return v.lower()
+
+    @field_validator("password")
+    @classmethod
+    def validate_password(cls, v: str) -> str:
+        if len(v) < 8:
+            raise ValueError("Password minimal 8 karakter")
+        if not re.search(r"[a-zA-Z]", v) or not re.search(r"\d", v):
+            raise ValueError("Password harus mengandung huruf dan angka")
+        return v
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        if len(v) < 2 or len(v) > 200:
+            raise ValueError("Nama harus berukuran 2 sampai 200 karakter")
+        return v
 
 
 class LoginRequest(BaseModel):
     email: str
     password: str
+
+    @field_validator("email")
+    @classmethod
+    def validate_email(cls, v: str) -> str:
+        email_regex = re.compile(r"^[a-zA-Z0-9_.+-]+@([a-zA-Z0-9-]+\.)*itk\.ac\.id$", re.IGNORECASE)
+        if not email_regex.match(v):
+            raise ValueError("Hanya email dengan domain itk.ac.id yang diperbolehkan")
+        return v.lower()
 
 
 class TokenResponse(BaseModel):
@@ -20,7 +52,15 @@ class TokenResponse(BaseModel):
 
 
 class UserBase(BaseModel):
-    name: str = Field(..., min_length=1)
+    name: str
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        if len(v) < 2 or len(v) > 200:
+            raise ValueError("Nama harus berukuran 2 sampai 200 karakter")
+        return v
+
     phone: str | None = None
 
 

--- a/services/auth-service/app/auth/schemas.py
+++ b/services/auth-service/app/auth/schemas.py
@@ -12,7 +12,8 @@ class RegisterRequest(BaseModel):
     @field_validator("email")
     @classmethod
     def validate_email(cls, v: str) -> str:
-        email_regex = re.compile(r"^[a-zA-Z0-9_.+-]+@([a-zA-Z0-9-]+\.)*itk\.ac\.id$", re.IGNORECASE)
+        v = v.strip()
+        email_regex = re.compile(r"^[a-zA-Z0-9_.+-]+@([a-zA-Z0-9-]+\.)*itk\.ac\.id\Z", re.IGNORECASE)
         if not email_regex.match(v):
             raise ValueError("Hanya email dengan domain itk.ac.id yang diperbolehkan")
         return v.lower()
@@ -29,6 +30,7 @@ class RegisterRequest(BaseModel):
     @field_validator("name")
     @classmethod
     def validate_name(cls, v: str) -> str:
+        v = v.strip()
         if len(v) < 2 or len(v) > 200:
             raise ValueError("Nama harus berukuran 2 sampai 200 karakter")
         return v
@@ -41,7 +43,8 @@ class LoginRequest(BaseModel):
     @field_validator("email")
     @classmethod
     def validate_email(cls, v: str) -> str:
-        email_regex = re.compile(r"^[a-zA-Z0-9_.+-]+@([a-zA-Z0-9-]+\.)*itk\.ac\.id$", re.IGNORECASE)
+        v = v.strip()
+        email_regex = re.compile(r"^[a-zA-Z0-9_.+-]+@([a-zA-Z0-9-]+\.)*itk\.ac\.id\Z", re.IGNORECASE)
         if not email_regex.match(v):
             raise ValueError("Hanya email dengan domain itk.ac.id yang diperbolehkan")
         return v.lower()
@@ -58,6 +61,7 @@ class UserBase(BaseModel):
     @field_validator("name")
     @classmethod
     def validate_name(cls, v: str) -> str:
+        v = v.strip()
         if len(v) < 2 or len(v) > 200:
             raise ValueError("Nama harus berukuran 2 sampai 200 karakter")
         return v

--- a/services/auth-service/app/main.py
+++ b/services/auth-service/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import JSONResponse, PlainTextResponse
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -40,9 +41,31 @@ async def add_security_headers(request, call_next):
     response = await call_next(request)
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
-    response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains; preload"
-    response.headers["Content-Security-Policy"] = "default-src 'self'; frame-ancestors 'none';"
+    response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains"
+    if request.url.path in ("/docs", "/redoc", "/openapi.json"):
+        # Swagger UI / ReDoc memuat aset dari cdn.jsdelivr.net; longgarkan CSP khusus path docs
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'self'; "
+            "img-src 'self' data: https://fastapi.tiangolo.com; "
+            "script-src 'self' https://cdn.jsdelivr.net; "
+            "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+            "worker-src 'self' blob:"
+        )
+    else:
+        response.headers["Content-Security-Policy"] = "default-src 'self'; frame-ancestors 'none';"
     return response
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request, exc: RequestValidationError):
+    """Normalkan body 422 jadi {"detail": "<pesan>"} (string), konsisten dengan
+    HTTPException lain dan kontrak yang dibaca frontend (response.data.detail)."""
+    errors = exc.errors()
+    if errors:
+        msg = str(errors[0].get("msg", "Input tidak valid")).replace("Value error, ", "")
+    else:
+        msg = "Input tidak valid"
+    return JSONResponse(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, content={"detail": msg})
 
 @app.get("/")
 def read_root():
@@ -62,6 +85,6 @@ def health_check(db: Session = Depends(get_db)):
             detail={"status": "unhealthy", "database": str(e)}
         ) from e
 
-@app.get("/metrics", response_class=PlainTextResponse)
+@app.get("/metrics", response_class=PlainTextResponse, include_in_schema=False)
 def metrics():
     return get_prometheus_metrics()

--- a/services/auth-service/app/main.py
+++ b/services/auth-service/app/main.py
@@ -35,6 +35,15 @@ app.add_middleware(
 # Register Request logging middleware
 app.add_middleware(RequestLoggingMiddleware)
 
+@app.middleware("http")
+async def add_security_headers(request, call_next):
+    response = await call_next(request)
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains; preload"
+    response.headers["Content-Security-Policy"] = "default-src 'self'; frame-ancestors 'none';"
+    return response
+
 @app.get("/")
 def read_root():
     return {"message": "Welcome to Temuin Auth Service"}

--- a/services/auth-service/tests/test_smoke.py
+++ b/services/auth-service/tests/test_smoke.py
@@ -7,6 +7,12 @@ def test_health_check(client):
     assert response.status_code == 200
     body = response.json()
     assert body["status"] == "healthy"
+    
+    # Sprint 8 BE-8.4: Verify security headers
+    assert response.headers.get("X-Content-Type-Options") == "nosniff"
+    assert response.headers.get("X-Frame-Options") == "DENY"
+    assert "Strict-Transport-Security" in response.headers
+    assert "Content-Security-Policy" in response.headers
 
 
 def test_register_invalid_email_rejected(client):

--- a/services/auth-service/tests/test_smoke.py
+++ b/services/auth-service/tests/test_smoke.py
@@ -7,7 +7,7 @@ def test_health_check(client):
     assert response.status_code == 200
     body = response.json()
     assert body["status"] == "healthy"
-    
+
     # Sprint 8 BE-8.4: Verify security headers
     assert response.headers.get("X-Content-Type-Options") == "nosniff"
     assert response.headers.get("X-Frame-Options") == "DENY"

--- a/services/auth-service/tests/test_smoke.py
+++ b/services/auth-service/tests/test_smoke.py
@@ -16,14 +16,16 @@ def test_health_check(client):
 
 
 def test_register_invalid_email_rejected(client):
-    """B-7 fix: validate_itk_email tolak domain yang bukan itk.ac.id atau subdomain."""
+    """B-7 fix: validate email tolak domain yang bukan itk.ac.id atau subdomain.
+    Sprint 8 BE-8.1/B2: validasi terjadi di schema layer -> 422 dengan detail string."""
     response = client.post(
         "/auth/register",
         json={"email": "user@notitk.ac.id", "password": "Password123", "name": "Test User"},
     )
-    assert response.status_code in (403, 422)
-    detail_str = str(response.json()["detail"]).lower()
-    assert "itk.ac.id" in detail_str
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert isinstance(detail, str)
+    assert "itk.ac.id" in detail.lower()
 
 
 def test_register_subdomain_email_accepted(client):

--- a/services/auth-service/tests/test_smoke.py
+++ b/services/auth-service/tests/test_smoke.py
@@ -15,8 +15,9 @@ def test_register_invalid_email_rejected(client):
         "/auth/register",
         json={"email": "user@notitk.ac.id", "password": "Password123", "name": "Test User"},
     )
-    assert response.status_code == 403
-    assert "itk.ac.id" in response.json()["detail"].lower()
+    assert response.status_code in (403, 422)
+    detail_str = str(response.json()["detail"]).lower()
+    assert "itk.ac.id" in detail_str
 
 
 def test_register_subdomain_email_accepted(client):
@@ -57,3 +58,27 @@ def test_users_admins_requires_auth(client):
     """B-1 fix: /auth/users/admins butuh auth."""
     response = client.get("/auth/users/admins")
     assert response.status_code in (401, 403)
+
+
+def test_register_validation_rules(client):
+    """Sprint 8 BE-8.1: Test validators for password strength and name length."""
+    # Invalid password: short
+    res = client.post("/auth/register", json={"email": "val@itk.ac.id", "password": "abc", "name": "Valid Name"})
+    assert res.status_code == 422
+
+    # Invalid password: no numbers
+    res = client.post("/auth/register", json={"email": "val@itk.ac.id", "password": "abcdefgh", "name": "Valid Name"})
+    assert res.status_code == 422
+
+    # Invalid password: no letters
+    res = client.post("/auth/register", json={"email": "val@itk.ac.id", "password": "12345678", "name": "Valid Name"})
+    assert res.status_code == 422
+
+    # Invalid name: too short
+    res = client.post("/auth/register", json={"email": "val@itk.ac.id", "password": "Password123", "name": "A"})
+    assert res.status_code == 422
+
+    # Invalid name: too long
+    res = client.post("/auth/register", json={"email": "val@itk.ac.id", "password": "Password123", "name": "A" * 201})
+    assert res.status_code == 422
+

--- a/services/engagement-service/app/claims/schemas.py
+++ b/services/engagement-service/app/claims/schemas.py
@@ -1,12 +1,19 @@
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class ClaimCreate(BaseModel):
     item_id: str
     ownership_answer: str
+
+    @field_validator("ownership_answer")
+    @classmethod
+    def validate_ownership_answer(cls, v: str) -> str:
+        if len(v.strip()) < 1:
+            raise ValueError("Jawaban bukti kepemilikan tidak boleh kosong")
+        return v
 
 class ClaimStatusUpdate(BaseModel):
     status: Literal["approved", "rejected", "completed", "cancelled"]

--- a/services/engagement-service/app/main.py
+++ b/services/engagement-service/app/main.py
@@ -38,6 +38,15 @@ app.add_middleware(
 # Register Request logging middleware
 app.add_middleware(RequestLoggingMiddleware)
 
+@app.middleware("http")
+async def add_security_headers(request, call_next):
+    response = await call_next(request)
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains; preload"
+    response.headers["Content-Security-Policy"] = "default-src 'self'; frame-ancestors 'none';"
+    return response
+
 @app.get("/")
 def read_root():
     return {"message": "Welcome to Temuin Engagement Service"}

--- a/services/engagement-service/app/main.py
+++ b/services/engagement-service/app/main.py
@@ -1,7 +1,8 @@
 import httpx
 from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import JSONResponse, PlainTextResponse
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -43,9 +44,31 @@ async def add_security_headers(request, call_next):
     response = await call_next(request)
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
-    response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains; preload"
-    response.headers["Content-Security-Policy"] = "default-src 'self'; frame-ancestors 'none';"
+    response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains"
+    if request.url.path in ("/docs", "/redoc", "/openapi.json"):
+        # Swagger UI / ReDoc memuat aset dari cdn.jsdelivr.net; longgarkan CSP khusus path docs
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'self'; "
+            "img-src 'self' data: https://fastapi.tiangolo.com; "
+            "script-src 'self' https://cdn.jsdelivr.net; "
+            "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+            "worker-src 'self' blob:"
+        )
+    else:
+        response.headers["Content-Security-Policy"] = "default-src 'self'; frame-ancestors 'none';"
     return response
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request, exc: RequestValidationError):
+    """Normalkan body 422 jadi {"detail": "<pesan>"} (string), konsisten dengan
+    HTTPException lain dan kontrak yang dibaca frontend (response.data.detail)."""
+    errors = exc.errors()
+    if errors:
+        msg = str(errors[0].get("msg", "Input tidak valid")).replace("Value error, ", "")
+    else:
+        msg = "Input tidak valid"
+    return JSONResponse(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, content={"detail": msg})
 
 @app.get("/")
 def read_root():
@@ -98,6 +121,6 @@ async def health_check(db: Session = Depends(get_db)):
         }
     }
 
-@app.get("/metrics", response_class=PlainTextResponse)
+@app.get("/metrics", response_class=PlainTextResponse, include_in_schema=False)
 def metrics():
     return get_prometheus_metrics()

--- a/services/engagement-service/app/notifications/schemas.py
+++ b/services/engagement-service/app/notifications/schemas.py
@@ -1,12 +1,30 @@
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class NotificationCreate(BaseModel):
     user_id: str
     title: str
     message: str
+
+    @field_validator("title")
+    @classmethod
+    def validate_title(cls, v: str) -> str:
+        if len(v.strip()) < 1:
+            raise ValueError("Title tidak boleh kosong")
+        if len(v) > 200:
+            raise ValueError("Title maksimal 200 karakter")
+        return v
+
+    @field_validator("message")
+    @classmethod
+    def validate_message(cls, v: str) -> str:
+        if len(v.strip()) < 1:
+            raise ValueError("Message tidak boleh kosong")
+        if len(v) > 2000:
+            raise ValueError("Message maksimal 2000 karakter")
+        return v
 
 class NotificationResponse(BaseModel):
     id: str

--- a/services/item-service/app/items/schemas.py
+++ b/services/item-service/app/items/schemas.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class ImageCreate(BaseModel):
@@ -17,6 +17,22 @@ class ItemCreate(BaseModel):
     security_officer_id: str | None = None
     images: list[ImageCreate] = []
 
+    @field_validator("title")
+    @classmethod
+    def validate_title(cls, v: str) -> str:
+        if len(v.strip()) < 1:
+            raise ValueError("Title tidak boleh kosong")
+        if len(v) > 200:
+            raise ValueError("Title maksimal 200 karakter")
+        return v
+
+    @field_validator("description")
+    @classmethod
+    def validate_description(cls, v: str | None) -> str | None:
+        if v is not None and len(v) > 2000:
+            raise ValueError("Description maksimal 2000 karakter")
+        return v
+
 class ItemUpdate(BaseModel):
     title: str | None = None
     description: str | None = None
@@ -25,6 +41,23 @@ class ItemUpdate(BaseModel):
     location_id: str | None = None
     security_officer_id: str | None = None
     status: str | None = Field(None, pattern="^(open|in_claim|returned|closed)$")
+
+    @field_validator("title")
+    @classmethod
+    def validate_title(cls, v: str | None) -> str | None:
+        if v is not None:
+            if len(v.strip()) < 1:
+                raise ValueError("Title tidak boleh kosong")
+            if len(v) > 200:
+                raise ValueError("Title maksimal 200 karakter")
+        return v
+
+    @field_validator("description")
+    @classmethod
+    def validate_description(cls, v: str | None) -> str | None:
+        if v is not None and len(v) > 2000:
+            raise ValueError("Description maksimal 2000 karakter")
+        return v
 
 class ItemStatusUpdate(BaseModel):
     status: str = Field(..., pattern="^(open|in_claim|returned|closed)$")

--- a/services/item-service/app/main.py
+++ b/services/item-service/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import JSONResponse, PlainTextResponse
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -41,9 +42,31 @@ async def add_security_headers(request, call_next):
     response = await call_next(request)
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
-    response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains; preload"
-    response.headers["Content-Security-Policy"] = "default-src 'self'; frame-ancestors 'none';"
+    response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains"
+    if request.url.path in ("/docs", "/redoc", "/openapi.json"):
+        # Swagger UI / ReDoc memuat aset dari cdn.jsdelivr.net; longgarkan CSP khusus path docs
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'self'; "
+            "img-src 'self' data: https://fastapi.tiangolo.com; "
+            "script-src 'self' https://cdn.jsdelivr.net; "
+            "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+            "worker-src 'self' blob:"
+        )
+    else:
+        response.headers["Content-Security-Policy"] = "default-src 'self'; frame-ancestors 'none';"
     return response
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request, exc: RequestValidationError):
+    """Normalkan body 422 jadi {"detail": "<pesan>"} (string), konsisten dengan
+    HTTPException lain dan kontrak yang dibaca frontend (response.data.detail)."""
+    errors = exc.errors()
+    if errors:
+        msg = str(errors[0].get("msg", "Input tidak valid")).replace("Value error, ", "")
+    else:
+        msg = "Input tidak valid"
+    return JSONResponse(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, content={"detail": msg})
 
 @app.get("/")
 def read_root():
@@ -64,6 +87,6 @@ def health_check(db: Session = Depends(get_db)):
             detail={"status": "unhealthy", "database": str(e)}
         ) from e
 
-@app.get("/metrics", response_class=PlainTextResponse)
+@app.get("/metrics", response_class=PlainTextResponse, include_in_schema=False)
 def metrics():
     return get_prometheus_metrics()

--- a/services/item-service/app/main.py
+++ b/services/item-service/app/main.py
@@ -36,6 +36,15 @@ app.add_middleware(
 # Register Request logging middleware
 app.add_middleware(RequestLoggingMiddleware)
 
+@app.middleware("http")
+async def add_security_headers(request, call_next):
+    response = await call_next(request)
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains; preload"
+    response.headers["Content-Security-Policy"] = "default-src 'self'; frame-ancestors 'none';"
+    return response
+
 @app.get("/")
 def read_root():
     return {"message": "Welcome to Temuin Item Service"}

--- a/services/item-service/app/master_data/schemas.py
+++ b/services/item-service/app/master_data/schemas.py
@@ -1,8 +1,15 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class MasterDataCreate(BaseModel):
     name: str
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        if len(v.strip()) < 2 or len(v) > 200:
+            raise ValueError("Nama master data harus berukuran 2 sampai 200 karakter")
+        return v
 
 class MasterDataResponse(BaseModel):
     id: str

--- a/services/item-service/app/utils/seed.py
+++ b/services/item-service/app/utils/seed.py
@@ -5,39 +5,43 @@ Dijalankan oleh entrypoint.sh saat container start dengan:
 
 Working from /app (WORKDIR di Dockerfile), modul `app` resolve normal.
 """
+import logging
+
 from app.database import SessionLocal
 from app.models import Building, Category, Location, SecurityOfficer
 
+logger = logging.getLogger(__name__)
+
 
 def seed_data():
-    print("Connecting to DB for seeding master data...")
+    logger.info("Connecting to DB for seeding master data...")
 
     db = SessionLocal()
     try:
         if db.query(Category).count() == 0:
-            print("Seeding Categories...")
+            logger.info("Seeding Categories...")
             for c in ["Elektronik", "Pakaian", "Dokumen", "Lainnya"]:
                 db.add(Category(name=c))
 
         if db.query(Building).count() == 0:
-            print("Seeding Buildings...")
+            logger.info("Seeding Buildings...")
             for b in ["Gedung A", "Gedung B", "Gedung C", "Gedung D"]:
                 db.add(Building(name=b))
 
         if db.query(Location).count() == 0:
-            print("Seeding Locations...")
+            logger.info("Seeding Locations...")
             for loc in ["Lobi Utama", "Kantin", "Perpustakaan", "Laboratorium"]:
                 db.add(Location(name=loc))
 
         if db.query(SecurityOfficer).count() == 0:
-            print("Seeding Security Officers...")
+            logger.info("Seeding Security Officers...")
             for o in ["Pak Budi", "Pak Agus", "Bu Siti"]:
                 db.add(SecurityOfficer(name=o))
 
         db.commit()
-        print("Master data seeding complete!")
+        logger.info("Master data seeding complete!")
     except Exception as e:
-        print(f"Error seeding master data: {e}")
+        logger.error("Error seeding master data: %s", e)
         db.rollback()
     finally:
         db.close()

--- a/temuin-docs/06-sprints/sprint-08.md
+++ b/temuin-docs/06-sprints/sprint-08.md
@@ -12,7 +12,7 @@ Tutup celah security yang disinggung Modul 15, finalisasi dokumen, siapkan demo 
 
 | ID | Task | Priority | Estimate | Depends On | Status | Branch/Ref | Notes |
 |----|------|----------|----------|------------|--------|------------|-------|
-| BE-8.1 | Audit Pydantic schema: semua input pakai `field_validator` + length limit + regex email itk.ac.id | High | 3h | BE-7.3 | todo | - | Modul 15: OWASP Top 10 (A03 Injection). Password min 8 char + huruf + angka, name 2..200, title max 200, description max 2000 |
+| BE-8.1 | Audit Pydantic schema: semua input pakai `field_validator` + length limit + regex email itk.ac.id | High | 3h | BE-7.3 | done | feat/sprint-8-backend | Modul 15: OWASP Top 10 (A03 Injection). Password min 8 char + huruf + angka, name 2..200, title max 200, description max 2000 |
 | BE-8.2 | Audit env vars: `JWT_SECRET`, `DATABASE_URL`, secret tidak masuk log atau response | High | 2h | BE-8.1 | todo | - | Modul 15: secret hygiene. `grep JWT_SECRET` di output `docker logs` semua service → 0 hit |
 | BE-8.3 | Tutup bug final yang mempengaruhi demo | High | 2h | BE-8.2 | todo | - | - |
 | BE-8.4 | Tambah security headers middleware: X-Content-Type-Options, X-Frame-Options, HSTS, CSP minimal | Medium | 2h | BE-8.1 | todo | - | Modul 15: security hardening. Verifikasi via `curl -I https://temuin.pangeransilaen.net` |

--- a/temuin-docs/06-sprints/sprint-08.md
+++ b/temuin-docs/06-sprints/sprint-08.md
@@ -16,7 +16,7 @@ Tutup celah security yang disinggung Modul 15, finalisasi dokumen, siapkan demo 
 | BE-8.2 | Audit env vars: `JWT_SECRET`, `DATABASE_URL`, secret tidak masuk log atau response | High | 2h | BE-8.1 | done | feat/sprint-8-backend | Modul 15: secret hygiene. `grep JWT_SECRET` di output `docker logs` semua service → 0 hit |
 | BE-8.3 | Tutup bug final yang mempengaruhi demo | High | 2h | BE-8.2 | done | feat/sprint-8-backend | - |
 | BE-8.4 | Tambah security headers middleware: X-Content-Type-Options, X-Frame-Options, HSTS, CSP minimal | Medium | 2h | BE-8.1 | done | feat/sprint-8-backend | Modul 15: security hardening. Verifikasi via `curl -I https://temuin.pangeransilaen.net` |
-| BE-8.5 | Code cleanup: hapus dead code, TODO, print statements; ganti ke `logger` | Medium | 2h | BE-8.3 | todo | - | Modul 15: code quality. `grep -rn "print(" services/` → 0 hit selain debug intended |
+| BE-8.5 | Code cleanup: hapus dead code, TODO, print statements; ganti ke `logger` | Medium | 2h | BE-8.3 | done | feat/sprint-8-backend | Modul 15: code quality. `grep -rn "print(" services/` → 0 hit selain debug intended |
 | BE-8.6 | Final swagger cleanup + Tutup endpoint internal dari public docs | Medium | 2h | BE-8.5 | todo | - | Modul 15: API documentation finalization |
 
 ## Lead Frontend (@nicholasmnrng)

--- a/temuin-docs/06-sprints/sprint-08.md
+++ b/temuin-docs/06-sprints/sprint-08.md
@@ -14,7 +14,7 @@ Tutup celah security yang disinggung Modul 15, finalisasi dokumen, siapkan demo 
 |----|------|----------|----------|------------|--------|------------|-------|
 | BE-8.1 | Audit Pydantic schema: semua input pakai `field_validator` + length limit + regex email itk.ac.id | High | 3h | BE-7.3 | done | feat/sprint-8-backend | Modul 15: OWASP Top 10 (A03 Injection). Password min 8 char + huruf + angka, name 2..200, title max 200, description max 2000 |
 | BE-8.2 | Audit env vars: `JWT_SECRET`, `DATABASE_URL`, secret tidak masuk log atau response | High | 2h | BE-8.1 | done | feat/sprint-8-backend | Modul 15: secret hygiene. `grep JWT_SECRET` di output `docker logs` semua service → 0 hit |
-| BE-8.3 | Tutup bug final yang mempengaruhi demo | High | 2h | BE-8.2 | todo | - | - |
+| BE-8.3 | Tutup bug final yang mempengaruhi demo | High | 2h | BE-8.2 | done | feat/sprint-8-backend | - |
 | BE-8.4 | Tambah security headers middleware: X-Content-Type-Options, X-Frame-Options, HSTS, CSP minimal | Medium | 2h | BE-8.1 | todo | - | Modul 15: security hardening. Verifikasi via `curl -I https://temuin.pangeransilaen.net` |
 | BE-8.5 | Code cleanup: hapus dead code, TODO, print statements; ganti ke `logger` | Medium | 2h | BE-8.3 | todo | - | Modul 15: code quality. `grep -rn "print(" services/` → 0 hit selain debug intended |
 | BE-8.6 | Final swagger cleanup + Tutup endpoint internal dari public docs | Medium | 2h | BE-8.5 | todo | - | Modul 15: API documentation finalization |

--- a/temuin-docs/06-sprints/sprint-08.md
+++ b/temuin-docs/06-sprints/sprint-08.md
@@ -17,7 +17,7 @@ Tutup celah security yang disinggung Modul 15, finalisasi dokumen, siapkan demo 
 | BE-8.3 | Tutup bug final yang mempengaruhi demo | High | 2h | BE-8.2 | done | feat/sprint-8-backend | - |
 | BE-8.4 | Tambah security headers middleware: X-Content-Type-Options, X-Frame-Options, HSTS, CSP minimal | Medium | 2h | BE-8.1 | done | feat/sprint-8-backend | Modul 15: security hardening. Verifikasi via `curl -I https://temuin.pangeransilaen.net` |
 | BE-8.5 | Code cleanup: hapus dead code, TODO, print statements; ganti ke `logger` | Medium | 2h | BE-8.3 | done | feat/sprint-8-backend | Modul 15: code quality. `grep -rn "print(" services/` → 0 hit selain debug intended |
-| BE-8.6 | Final swagger cleanup + Tutup endpoint internal dari public docs | Medium | 2h | BE-8.5 | todo | - | Modul 15: API documentation finalization |
+| BE-8.6 | Final swagger cleanup + Tutup endpoint internal dari public docs | Medium | 2h | BE-8.5 | done | feat/sprint-8-backend | Modul 15: API documentation finalization |
 
 ## Lead Frontend (@nicholasmnrng)
 

--- a/temuin-docs/06-sprints/sprint-08.md
+++ b/temuin-docs/06-sprints/sprint-08.md
@@ -13,7 +13,7 @@ Tutup celah security yang disinggung Modul 15, finalisasi dokumen, siapkan demo 
 | ID | Task | Priority | Estimate | Depends On | Status | Branch/Ref | Notes |
 |----|------|----------|----------|------------|--------|------------|-------|
 | BE-8.1 | Audit Pydantic schema: semua input pakai `field_validator` + length limit + regex email itk.ac.id | High | 3h | BE-7.3 | done | feat/sprint-8-backend | Modul 15: OWASP Top 10 (A03 Injection). Password min 8 char + huruf + angka, name 2..200, title max 200, description max 2000 |
-| BE-8.2 | Audit env vars: `JWT_SECRET`, `DATABASE_URL`, secret tidak masuk log atau response | High | 2h | BE-8.1 | todo | - | Modul 15: secret hygiene. `grep JWT_SECRET` di output `docker logs` semua service → 0 hit |
+| BE-8.2 | Audit env vars: `JWT_SECRET`, `DATABASE_URL`, secret tidak masuk log atau response | High | 2h | BE-8.1 | done | feat/sprint-8-backend | Modul 15: secret hygiene. `grep JWT_SECRET` di output `docker logs` semua service → 0 hit |
 | BE-8.3 | Tutup bug final yang mempengaruhi demo | High | 2h | BE-8.2 | todo | - | - |
 | BE-8.4 | Tambah security headers middleware: X-Content-Type-Options, X-Frame-Options, HSTS, CSP minimal | Medium | 2h | BE-8.1 | todo | - | Modul 15: security hardening. Verifikasi via `curl -I https://temuin.pangeransilaen.net` |
 | BE-8.5 | Code cleanup: hapus dead code, TODO, print statements; ganti ke `logger` | Medium | 2h | BE-8.3 | todo | - | Modul 15: code quality. `grep -rn "print(" services/` → 0 hit selain debug intended |

--- a/temuin-docs/06-sprints/sprint-08.md
+++ b/temuin-docs/06-sprints/sprint-08.md
@@ -15,7 +15,7 @@ Tutup celah security yang disinggung Modul 15, finalisasi dokumen, siapkan demo 
 | BE-8.1 | Audit Pydantic schema: semua input pakai `field_validator` + length limit + regex email itk.ac.id | High | 3h | BE-7.3 | done | feat/sprint-8-backend | Modul 15: OWASP Top 10 (A03 Injection). Password min 8 char + huruf + angka, name 2..200, title max 200, description max 2000 |
 | BE-8.2 | Audit env vars: `JWT_SECRET`, `DATABASE_URL`, secret tidak masuk log atau response | High | 2h | BE-8.1 | done | feat/sprint-8-backend | Modul 15: secret hygiene. `grep JWT_SECRET` di output `docker logs` semua service → 0 hit |
 | BE-8.3 | Tutup bug final yang mempengaruhi demo | High | 2h | BE-8.2 | done | feat/sprint-8-backend | - |
-| BE-8.4 | Tambah security headers middleware: X-Content-Type-Options, X-Frame-Options, HSTS, CSP minimal | Medium | 2h | BE-8.1 | todo | - | Modul 15: security hardening. Verifikasi via `curl -I https://temuin.pangeransilaen.net` |
+| BE-8.4 | Tambah security headers middleware: X-Content-Type-Options, X-Frame-Options, HSTS, CSP minimal | Medium | 2h | BE-8.1 | done | feat/sprint-8-backend | Modul 15: security hardening. Verifikasi via `curl -I https://temuin.pangeransilaen.net` |
 | BE-8.5 | Code cleanup: hapus dead code, TODO, print statements; ganti ke `logger` | Medium | 2h | BE-8.3 | todo | - | Modul 15: code quality. `grep -rn "print(" services/` → 0 hit selain debug intended |
 | BE-8.6 | Final swagger cleanup + Tutup endpoint internal dari public docs | Medium | 2h | BE-8.5 | todo | - | Modul 15: API documentation finalization |
 


### PR DESCRIPTION
## Deskripsi
Implementasi seluruh backlog untuk Sprint 8  yang berfokus pada Security Hardening, audit variabel lingkungan (secret hygiene), penutupan bug demo, penambahan middleware security headers, code cleanup, serta pembersihan OpenAPI/Swagger docs untuk menyembunyikan endpoint internal.

---

## Daftar Backlog & Status
- [x] **BE-8.1**: Audit Pydantic schema (validasi email `@itk.ac.id`, password aman, batas panjang nama, judul, & deskripsi).
- [x] **BE-8.2**: Audit variabel lingkungan (tidak ada kebocoran rahasia seperti `JWT_SECRET`/`DATABASE_URL` ke log).
- [x] **BE-8.3**: Verifikasi & tutup bug final yang memengaruhi demo.
- [x] **BE-8.4**: Penambahan middleware security headers (`HSTS`, `CSP`, `X-Frame-Options`, `X-Content-Type-Options`).
- [x] **BE-8.5**: Code cleanup (pembersihan dead code, `TODO`/`FIXME`, dan `print` statements).
- [x] **BE-8.6**: Penyembunyian endpoint service-to-service internal dari public OpenAPI/Swagger docs.

---

## Detail Perubahan & Berkas yang Diubah

### `services/auth-service`
* **schemas.py**:
  * Validator email khusus domain `itk.ac.id` (termasuk subdomain).
  * Validator password minimal 8 karakter dengan kombinasi angka dan huruf.
  * Validator nama minimal 2 karakter, maksimal 200 karakter.
* **main.py**:
  * Penambahan middleware HTTP untuk menyuntikkan security headers.
* **router.py**:
  * Menambahkan `include_in_schema=False` pada endpoint internal `/users/admins` dan `/users/{user_id}`.
* **test_smoke.py**:
  * Penambahan asersi pengujian kekuatan password, panjang nama, dan kebenaran header HTTP respon.

### `services/item-service`
* **schemas.py (items)**:
  * Validasi panjang judul (max 200) dan deskripsi (max 2000).
* **schemas.py (master data)**:
  * Validasi panjang nama master data (2-200).
* **main.py**:
  * Penambahan middleware HTTP security headers.

### `services/engagement-service`
* **schemas.py (claims)**:
  * Validasi field `ownership_answer` agar tidak kosong.
* **schemas.py (notifications)**:
  * Validasi panjang judul notifikasi (max 200) dan pesan (max 2000).
* **main.py**:
  * Penambahan middleware HTTP security headers.

---

## Langkah Verifikasi & Pengujian
- Menjalankan unit test lokal pada setiap service:
  * **Auth Service**: `pytest services/auth-service/tests` (6/6 passed)
  * **Item Service**: `pytest services/item-service/tests` (7/7 passed)
  * **Engagement Service**: `pytest services/engagement-service/tests` (14/14 passed)
- Lolos validasi Ruff linter lokal (`All checks passed!`).