### PR TITLE
feat(devops): Sprint 8 image hardening + CD safety + release notes (DO-8.1/8.3/8.5)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -123,6 +123,15 @@ jobs:
             $COMPOSE pull
             echo "=== Restarting containers ==="
             $COMPOSE up -d
+            # Gateway config di-bind-mount ke nginx:alpine. `up -d` tidak
+            # me-recreate gateway saat hanya isi file config berubah (image &
+            # definisi service tetap), jadi nginx masih pegang config lama di
+            # memory. Reload eksplisit supaya perubahan gateway/nginx.conf
+            # (mis. upstream frontend:8080 di DO-8.1) benar-benar aktif.
+            # Zero-downtime; fallback force-recreate kalau exec gagal.
+            echo "=== Reloading gateway config ==="
+            docker exec temuin-gateway nginx -t && docker exec temuin-gateway nginx -s reload \
+              || $COMPOSE up -d --force-recreate gateway
             echo "=== Waiting for health checks (30s) ==="
             sleep 30
             echo "=== Service status ==="
@@ -139,11 +148,14 @@ jobs:
             HEALTH_AUTH=$(curl -fsS -o /dev/null -w "%{http_code}" https://temuin.pangeransilaen.net/api/auth/health || echo "fail")
             HEALTH_ITEM=$(curl -fsS -o /dev/null -w "%{http_code}" https://temuin.pangeransilaen.net/api/items/health || echo "fail")
             HEALTH_ENG=$(curl -fsS -o /dev/null -w "%{http_code}" https://temuin.pangeransilaen.net/api/engagement/health || echo "fail")
+            # Cek frontend root juga (SPA via gateway -> frontend). Tanpa ini
+            # CD bisa hijau walau frontend mati / gateway salah upstream port.
+            HEALTH_FE=$(curl -fsS -o /dev/null -w "%{http_code}" https://temuin.pangeransilaen.net/ || echo "fail")
             STATUS_JSON=$(curl -fsS https://temuin.pangeransilaen.net/api/status || echo "fail")
             STATUS_OK=$(printf '%s' "$STATUS_JSON" | python3 -c 'import json,sys; data=json.load(sys.stdin); services=data.get("services", []); sys.exit(0 if isinstance(services, list) and len(services) == 3 else 1)' && echo "200" || echo "fail")
-            echo "auth=$HEALTH_AUTH item=$HEALTH_ITEM engagement=$HEALTH_ENG status=$STATUS_OK"
-            if [ "$HEALTH_AUTH" = "200" ] && [ "$HEALTH_ITEM" = "200" ] && [ "$HEALTH_ENG" = "200" ] && [ "$STATUS_OK" = "200" ]; then
-              echo "All 3 services healthy and /api/status returns JSON services"
+            echo "auth=$HEALTH_AUTH item=$HEALTH_ITEM engagement=$HEALTH_ENG frontend=$HEALTH_FE status=$STATUS_OK"
+            if [ "$HEALTH_AUTH" = "200" ] && [ "$HEALTH_ITEM" = "200" ] && [ "$HEALTH_ENG" = "200" ] && [ "$HEALTH_FE" = "200" ] && [ "$STATUS_OK" = "200" ]; then
+              echo "All 3 services + frontend healthy and /api/status returns JSON services"
               exit 0
             fi
             if [ $i -eq 3 ]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,8 @@ services:
     container_name: temuin-frontend
     restart: unless-stopped
     ports:
-      - "3000:80"
+      # Container nginx non-root listen 8080 (DO-8.1)
+      - "3000:8080"
     depends_on:
       backend:
         condition: service_healthy

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,76 @@
+# Release Notes — Temuin v1.0.0
+
+**Tanggal rilis:** 2026-06-11
+**Live URL:** https://temuin.pangeransilaen.net
+**Kode:** tag `v1.0.0` di branch `master`
+
+Temuin adalah platform lost & found kampus ITK: pengguna melaporkan barang hilang/ditemukan, mengajukan klaim dengan bukti kepemilikan, dan admin memverifikasi sampai barang kembali ke pemiliknya.
+
+---
+
+## Highlights
+
+### Arsitektur
+- **Microservices (3 service)** di belakang satu API gateway:
+  - `auth-service` (8001) — identity, register, login, JWT issuance
+  - `item-service` (8002) — items, item images, master data (kategori, gedung, lokasi, petugas)
+  - `engagement-service` (8003) — claims, notifications, audit log, status aggregator
+- **Production gateway** (`nginx`) sebagai single entry point: reverse proxy `/api/*` ke 3 service dan `/` ke frontend SPA.
+- **Frontend** React + Vite + Tailwind CSS + shadcn/ui, disajikan via nginx.
+- **Database** PostgreSQL 16 dengan 3 logical DB (`auth_db`, `item_db`, `engagement_db`).
+
+### Fitur utama
+- Register/login dengan email domain `itk.ac.id` (termasuk subdomain) + JWT.
+- Lapor barang hilang (`lost`) dan ditemukan (`found`) lengkap dengan gambar dan master data.
+- Alur klaim end-to-end: ajukan klaim → verifikasi bukti kepemilikan → approve/reject → completed.
+- Notifikasi in-app dan riwayat status.
+- Panel admin: kelola klaim dan master data.
+
+### Keamanan (Sprint 8 — Modul 15)
+- **Input validation** menyeluruh via Pydantic `field_validator`: password min 8 char (huruf + angka), batas panjang nama/judul/deskripsi, regex email ITK ter-anchor.
+- **Security headers** di semua service: `X-Content-Type-Options`, `X-Frame-Options`, `HSTS`, `Content-Security-Policy` (docs-aware agar Swagger tetap jalan).
+- **Image hardening**: seluruh container berjalan sebagai non-root (backend uid 1000, frontend nginx uid 101).
+- **Rate limiting** di gateway: zona auth 5r/s (burst 10), umum 30r/s (burst 50), respons 429 JSON.
+- **Correlation ID** lintas service untuk tracing.
+- **Secret hygiene**: `.env*` di-gitignore; secret production tidak masuk log maupun response.
+
+### Operasional
+- **CI** (GitHub Actions): lint, unit/smoke test per service, frontend build + vitest, integration test gateway + microservices (khusus PR).
+- **CD** (GitHub Actions): build & push 4 image ke Docker Hub → deploy ke Tencent VPS → health check otomatis (3 service + frontend + `/api/status`).
+- **Observability**: log JSON terstruktur, rotasi 10m × 3, helper `scripts/logs.sh` (all/errors/trace/metrics).
+- **Deployment**: Tencent VPS Ubuntu 22.04, host nginx (SSL termination via Certbot) → gateway `:8080`.
+
+---
+
+## Migration Notes
+
+> Catatan untuk siapa pun yang melakukan deploy/upgrade dari versi sebelum v1.0.0.
+
+- **Port internal frontend berubah `80` → `8080`** (akibat image nginx non-root, DO-8.1). Yang ikut berubah dan sudah disinkronkan:
+  - `gateway/nginx.conf`: upstream `frontend:8080`
+  - `infra/docker-compose.microservices.yml`: mapping `127.0.0.1:3000:8080`
+  - `docker-compose.yml` (monolith fallback): `3000:8080`
+- **Gateway perlu reload setelah deploy.** Karena `gateway/nginx.conf` di-bind-mount ke `nginx:alpine`, `docker compose up -d` tidak otomatis memuat ulang config saat hanya isi file yang berubah. CD sudah menambahkan `nginx -s reload` eksplisit (fallback force-recreate). Untuk deploy manual: `docker exec temuin-gateway nginx -t && docker exec temuin-gateway nginx -s reload`.
+- **Tidak ada perubahan skema database** yang merusak (semua tabel dibuat otomatis saat startup via `Base.metadata.create_all`). Tidak ada migrasi destruktif.
+- **`SECRET_KEY` production** harus tetap di-set di `/opt/temuin/.env` (bukan placeholder). Jangan pakai nilai contoh dari `.env.docker`.
+
+---
+
+## Known Limitations
+
+- **Frontend `:3000` masih dipertahankan** sebagai jalur transisi zero-downtime di samping gateway `:8080`. Bisa dibersihkan di iterasi berikutnya setelah gateway terbukti stabil.
+- **Log backend menampilkan `"service":"unknown-service"`** pada sebagian entri (ranah BE-7.3); tidak memengaruhi fungsionalitas, hanya label observability.
+- **Secret bocor di git history**: sebuah `SECRET_KEY` asli pernah ter-commit di `.env.docker` pada Sprint 3 lalu diganti placeholder. Secret production **sudah berbeda** dari nilai bocor (sudah ter-rotate), jadi tidak ter-eksploitasi. Pembersihan history (rewrite) belum dilakukan karena berisiko tinggi terhadap clone tim; dicatat sebagai utang teknis.
+- **Integration test CI kadang flaky** karena race startup upstream (gateway healthy lebih dulu dari item-service). Mitigasi disarankan: tunggu seluruh upstream healthy sebelum smoke test.
+- **Validasi kepemilikan klaim** berbasis jawaban teks bebas (manual review oleh admin), belum ada scoring otomatis.
+
+---
+
+## Tim
+
+| Role     | Anggota          |
+| -------- | ---------------- |
+| Backend  | @disnejy         |
+| Frontend | @nicholasmnrng   |
+| DevOps   | @PangeranSilaen  |
+| QA & Docs | @raniayudewi    |

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -31,9 +31,15 @@ COPY . .
 RUN npm run build
 
 # ============================================================
-# Stage 2: Serve with Nginx
+# Stage 2: Serve with Nginx (non-root, DEC-018 / DO-8.1)
 # ============================================================
-FROM nginx:alpine
+# nginxinc/nginx-unprivileged jalan sebagai uid 101 dan listen di
+# 8080 (non-privileged port). Build-time file setup butuh root,
+# lalu container runtime balik ke uid 101.
+FROM nginxinc/nginx-unprivileged:alpine
+
+# Switch ke root hanya untuk setup file saat build
+USER root
 
 # Remove default nginx config
 RUN rm /etc/nginx/conf.d/default.conf
@@ -44,9 +50,12 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 # Copy built files from build stage
 COPY --from=build /app/dist /usr/share/nginx/html
 
-EXPOSE 80
+# Security: runtime sebagai non-root nginx user (uid 101)
+USER 101
+
+EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD wget -qO- http://127.0.0.1:80/ > /dev/null 2>&1 || exit 1
+    CMD wget -qO- http://127.0.0.1:8080/ > /dev/null 2>&1 || exit 1
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     server_name localhost;
 
     root /usr/share/nginx/html;

--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -47,7 +47,7 @@ log_format gateway escape=json
 upstream auth_upstream       { server auth-service:8001; }
 upstream item_upstream       { server item-service:8002; }
 upstream engagement_upstream { server engagement-service:8003; }
-upstream frontend_upstream   { server frontend:80; }
+upstream frontend_upstream   { server frontend:8080; }
 
 server {
     listen 8080;
@@ -134,7 +134,7 @@ server {
     }
 
     # ============================================================
-    # FRONTEND (everything else -> frontend:80, SPA)
+    # FRONTEND (everything else -> frontend:8080, SPA)
     # ============================================================
     location / {
         proxy_pass http://frontend_upstream;

--- a/infra/docker-compose.microservices.yml
+++ b/infra/docker-compose.microservices.yml
@@ -160,7 +160,8 @@ services:
       # Dipertahankan untuk transisi zero-downtime: host nginx VPS lama
       # forward ke :3000 sampai DO-7.9 repoint ke gateway :8080. Local
       # runner (scripts/temuin.ps1) juga pakai :3000.
-      - "127.0.0.1:3000:80"
+      # Container listen 8080 (nginx-unprivileged / non-root, DO-8.1).
+      - "127.0.0.1:3000:8080"
     depends_on:
       - auth-service
       - item-service

--- a/services/auth-service/Dockerfile
+++ b/services/auth-service/Dockerfile
@@ -56,8 +56,8 @@ COPY . .
 # Make entrypoint executable
 RUN chmod +x /app/entrypoint.sh
 
-# Security: run as non-root user
-RUN adduser -D appuser && chown -R appuser:appuser /app
+# Security: run as non-root user (uid 1000, DEC-018 / DO-8.1)
+RUN adduser -D -u 1000 appuser && chown -R appuser:appuser /app
 USER appuser
 
 EXPOSE 8001

--- a/services/engagement-service/Dockerfile
+++ b/services/engagement-service/Dockerfile
@@ -56,8 +56,8 @@ COPY . .
 # Make entrypoint executable
 RUN chmod +x /app/entrypoint.sh
 
-# Security: run as non-root user
-RUN adduser -D appuser && chown -R appuser:appuser /app
+# Security: run as non-root user (uid 1000, DEC-018 / DO-8.1)
+RUN adduser -D -u 1000 appuser && chown -R appuser:appuser /app
 USER appuser
 
 EXPOSE 8003

--- a/services/item-service/Dockerfile
+++ b/services/item-service/Dockerfile
@@ -56,8 +56,8 @@ COPY . .
 # Make entrypoint executable
 RUN chmod +x /app/entrypoint.sh
 
-# Security: run as non-root user
-RUN adduser -D appuser && chown -R appuser:appuser /app
+# Security: run as non-root user (uid 1000, DEC-018 / DO-8.1)
+RUN adduser -D -u 1000 appuser && chown -R appuser:appuser /app
 USER appuser
 
 EXPOSE 8002

--- a/temuin-docs/03-architecture/devops-architecture.md
+++ b/temuin-docs/03-architecture/devops-architecture.md
@@ -84,7 +84,7 @@ File `gateway/nginx.conf`:
 - `/api/items/*`, `/api/categories/*`, `/api/buildings/*`, `/api/locations/*`, `/api/security-officers/*` → `item-service:8002`
 - `/api/claims/*`, `/api/notifications/*`, `/api/audit-logs/*` → `engagement-service:8003`
 - `/api/status` → aggregator (lokal di gateway atau forward ke engagement-service)
-- `/` → `frontend:80`
+- `/` → `frontend:8080`
 
 ### Rate Limiting (DEC-023)
 - Zone `auth_zone` 5r/s burst 10 untuk `/api/auth/login` dan `/api/auth/register`


### PR DESCRIPTION
## Ringkasan
DevOps Sprint 8 (Modul 15) - image hardening non-root, perbaikan keamanan CD, dan release notes.

## DO-8.1 Image hardening (DEC-018)
- **Frontend**: ganti base ke `nginxinc/nginx-unprivileged:alpine`, runtime sebagai **uid 101**, listen **8080** (port non-privileged). Build-time setup pakai root, runtime balik ke 101.
- **Backend** (3 service): pin `appuser` ke **uid 1000** (`adduser -D -u 1000`).
- Sinkronkan port frontend **80 -> 8080** di: `gateway/nginx.conf` (upstream), `infra/docker-compose.microservices.yml` (3000:8080), `docker-compose.yml` monolith fallback, dan doc arsitektur.

## DO-8.3 prep (CD safety untuk perubahan ini)
Dua latent bug yang ditemukan saat menyiapkan deploy:
1. **Gateway tidak auto-reload**: `gateway/nginx.conf` di-bind-mount ke `nginx:alpine`. `docker compose up -d` tidak me-recreate gateway saat hanya isi config berubah, jadi nginx masih pegang `upstream frontend:80` lama -> 502 di `/`. Fix: `nginx -s reload` eksplisit (fallback force-recreate).
2. **Health check buta terhadap frontend**: CD cuma cek `/api/*`, jadi bisa hijau walau frontend mati. Fix: tambah cek `/`.

## DO-8.5 prep
- `docs/release-notes.md` (highlights, migration notes, known limitations). **Git tag v1.0.0 belum dibuat** - nunggu deploy final.

## Verifikasi lokal
- frontend non-root: `id` -> uid=101(nginx), nginx master non-root, listen 8080, HTTP `/` -> 200
- gateway -> frontend:8080 wiring (mini-stack isolated): `/` -> 200, `/api/status` -> 502 (routing nyampe upstream)
- uid 1000 free + `adduser -u 1000` works di `python:3.12-alpine`
- stack lokal asli tidak terganggu (semua resource test dibersihkan)

## Catatan
- **DO-8.3 deploy production & DO-8.5 git tag belum dijalankan** - sesuai kesepakatan, dilakukan bersama user.
- Temuan DO-8.2 (audit env): `.gitignore` benar, `.env.docker` placeholder. Ada `SECRET_KEY` asli yang pernah ke-commit di git history (Sprint 3) tapi **production sudah pakai secret berbeda** (ter-rotate, tidak ter-eksploitasi). History rewrite tidak dilakukan (high-risk); dicatat di release notes.