### PR TITLE
docs(devops): Sprint 8 status + demo script + sync deploy docs (DO-8.4/8.6)

### DIFF
--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -1,0 +1,91 @@
+# Demo Script — Temuin (Backup Video UAS, DO-8.4)
+
+Panduan rekam layar 5 menit untuk safety-net demo UAS. Rekam seluruh alur utama secara berurutan, lalu upload ke Google Drive dan tempel link-nya di `docs/final-checklist.md` (QA-8.3).
+
+- **Live URL:** https://temuin.pangeransilaen.net
+- **Target durasi:** ~5 menit
+- **Tool rekam:** OBS / screen recorder bawaan OS (1080p, sertakan audio narasi opsional)
+- **Sebelum rekam:** clear browser cache / pakai jendela incognito, tutup tab lain, pastikan VPS up (`/api/status` 3 service `up`), dan DB sudah ter-seed (kategori, gedung, lokasi, petugas).
+
+---
+
+## Persiapan kredensial (sebelum mulai rekam)
+
+Siapkan 2 akun untuk menunjukkan alur klaim antar-pengguna + 1 akun admin:
+
+| Peran           | Email (contoh)                | Catatan                                   |
+| --------------- | ----------------------------- | ----------------------------------------- |
+| User A (pelapor found) | `demo.found@itk.ac.id`        | Yang menemukan & melaporkan barang        |
+| User B (pengklaim)     | `demo.claim@itk.ac.id`        | Yang merasa barang itu miliknya           |
+| Admin           | (akun admin yang sudah ada)   | Verifikasi & approve klaim, kelola master data |
+
+Password contoh: `Password123` (min 8 char, ada huruf + angka).
+
+---
+
+## Alur rekaman (urutan adegan)
+
+### 1. Landing + Status page (~20 dtk)
+1. Buka `https://temuin.pangeransilaen.net`.
+2. Tunjukkan halaman utama (SPA load cepat).
+3. Buka halaman `/status` — perlihatkan 3 service `up` (bukti microservices hidup via gateway).
+
+### 2. Register + Login (~40 dtk)
+1. Register **User A** (`demo.found@itk.ac.id`). Tunjukkan validasi: coba email non-ITK → ditolak pesan jelas; coba password lemah → ditolak.
+2. Register dengan data valid → otomatis login / dapat token.
+3. (Opsional) tunjukkan logout lalu login ulang untuk menegaskan auth bekerja.
+
+### 3. Lapor barang DITEMUKAN (found) — User A (~50 dtk)
+1. Masuk menu buat laporan, pilih tipe **found**.
+2. Isi judul, deskripsi, kategori, gedung, lokasi, petugas (master data dari dropdown).
+3. Upload gambar barang.
+4. Submit → barang muncul di daftar. Buka detailnya.
+
+### 4. Lapor barang HILANG (lost) — User A (~25 dtk)
+1. Buat satu laporan tipe **lost** (tunjukkan kedua tipe didukung).
+2. Submit → tampil di daftar dengan label `lost`.
+
+### 5. Ajukan klaim — User B (~50 dtk)
+1. Logout User A, login **User B** (`demo.claim@itk.ac.id`).
+2. Buka barang **found** milik User A dari daftar.
+3. Klik ajukan klaim → isi jawaban bukti kepemilikan (ciri spesifik barang).
+4. Submit klaim → status klaim `pending`.
+
+### 6. Verifikasi & approve klaim — Admin (~60 dtk)
+1. Logout, login **Admin**.
+2. Buka panel admin → daftar klaim.
+3. Buka detail klaim User B, baca jawaban bukti kepemilikan.
+4. **Approve** klaim → status berubah `approved`.
+5. Tandai **completed** (barang diserahkan) → status `completed`, item jadi `returned`/`closed`.
+
+### 7. Notifikasi (~25 dtk)
+1. Logout, login **User B**.
+2. Buka halaman notifikasi → tunjukkan notifikasi klaim disetujui/selesai.
+
+### 8. Profile (~20 dtk)
+1. Buka halaman profil User B.
+2. Edit nama / no HP → simpan → perlihatkan perubahan tersimpan.
+
+### 9. Admin master data (~30 dtk)
+1. Login Admin → panel master data.
+2. Tambah satu entitas (mis. kategori baru) → muncul di daftar.
+3. (Opsional) edit / hapus untuk menunjukkan CRUD admin.
+
+### 10. Penutup (~15 dtk)
+1. Kembali ke `/status` → 3 service tetap `up`.
+2. (Opsional) singgung security: HTTPS aktif, rate limit, container non-root.
+
+---
+
+## Checklist pasca-rekam
+- [ ] Durasi ≤ ~5 menit, semua adegan jelas terlihat.
+- [ ] Tidak ada kredensial sensitif asli yang tampil mencolok.
+- [ ] Upload ke Google Drive (akses: anyone with link / sesuai kebutuhan dosen).
+- [ ] Tempel link video di `docs/final-checklist.md` (QA-8.3).
+
+---
+
+## Catatan teknis (jika ada kendala saat rekam)
+- Kalau muncul toast error, salin `X-Correlation-ID` dari DevTools → Network, lalu trace di VPS: `cd /opt/temuin && ./scripts/logs.sh trace <id>`.
+- Kalau `/status` tidak 3 `up`, cek container: `docker ps --filter name=temuin` (semua harus `healthy`).
+- Rate limit (429) bisa muncul kalau spam login; tunggu beberapa detik.

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -96,7 +96,7 @@ Untuk memastikan penggunaan memori server tetap efisien dan tidak menyentuh bata
 ```bash
 make stats-micro
 ```
-Perintah ini akan mengeluarkan data konsumsi RAM dan CPU dari kelima kontainer (`temuin-db`, `temuin-auth`, `temuin-item`, `temuin-engagement`, dan `temuin-frontend`).
+Perintah ini akan mengeluarkan data konsumsi RAM dan CPU dari keenam kontainer (`temuin-db`, `temuin-auth`, `temuin-item`, `temuin-engagement`, `temuin-frontend`, dan `temuin-gateway`).
 
 ### 4.3 Log Rotation (Rotasi Berkas Log)
 Untuk mencegah disk server penuh akibat berkas log kontainer yang membengkak, Temuin telah mengonfigurasi rotasi log otomatis di `docker-compose.microservices.yml` menggunakan driver bawaan Docker:

--- a/temuin-docs/03-architecture/devops-architecture.md
+++ b/temuin-docs/03-architecture/devops-architecture.md
@@ -106,6 +106,11 @@ File `gateway/nginx.conf`:
 - Correlation ID memakai `$request_id` nginx (di-trim 12 karakter via `map`); kalau client sudah mengirim `X-Correlation-ID`, nilai itu dipakai apa adanya.
 - Gateway tidak butuh image terpisah di CD `build-and-push`; CD cukup scp `infra/docker-compose.microservices.yml` + `gateway/nginx.conf` ke `/opt/temuin/` (layout mirror repo agar bind-mount relatif resolve).
 
+### Catatan Implementasi Sprint 8 (DO-8.1/8.3)
+- Karena `gateway/nginx.conf` di-bind-mount ke `nginx:alpine`, `docker compose up -d` TIDAK me-recreate gateway saat hanya isi config berubah (image & definisi service tetap) — nginx masih pegang config lama di memory. CD `deploy` kini menjalankan `nginx -t && nginx -s reload` eksplisit setelah `up -d` (fallback `--force-recreate gateway`) supaya perubahan upstream (mis. `frontend:8080`) benar-benar aktif.
+- Health check CD ditambah cek frontend `/` (sebelumnya hanya `/api/*`), supaya deploy tidak hijau-palsu saat frontend mati / gateway salah upstream port.
+- Frontend non-root menggeser listen `80 -> 8080`; routing `/api` warisan di `frontend/nginx.conf` masih dipertahankan (belum dibersihkan) demi jalur transisi `:3000`.
+
 ## Observability Ops (DEC-022, Sprint 7)
 
 ### Log Driver
@@ -129,31 +134,32 @@ File `docker-compose.yml`:
 
 ## Security (Sprint 8, DEC-023)
 
-### Image Hardening
-- Backend Dockerfile pakai `USER appuser` (uid 1000), tidak run sebagai root
-- Frontend nginx pakai `--user 101:101` (nginx user di alpine)
-- `.dockerignore` pastikan `.env`, `__pycache__`, `node_modules` tidak masuk image
+### Image Hardening (DO-8.1)
+- Backend Dockerfile (auth/item/engagement) pakai `USER appuser` dengan uid di-pin **1000** (`adduser -D -u 1000`), tidak run sebagai root.
+- Frontend pakai base image `nginxinc/nginx-unprivileged:alpine` (runtime `USER 101`), nginx **listen 8080** (port non-privileged). Akibatnya container frontend mapping `127.0.0.1:3000:8080` dan gateway upstream jadi `frontend:8080`.
+- Verifikasi production (`docker exec <c> id -u`): auth/item/engagement = `1000`, frontend = `101`. (Gateway `nginx:alpine` master tetap uid 0 — perilaku standar nginx, worker drop ke non-priv; di luar scope DO-8.1.)
+- `.dockerignore` pastikan `.env`, `__pycache__`, `node_modules` tidak masuk image.
 
-### Secrets Audit
-- `.env.example` lengkap di repo (placeholder, no real secret)
-- `.env`, `.env.production`, `.env.docker` wajib di `.gitignore`
-- Verifikasi dengan `git log --all --full-history -- '.env'` empty
-- `JWT_SECRET` minimum 32 karakter random hex (`openssl rand -hex 32`)
-- `SECRET_KEY` Postgres password generate fresh, tidak reuse
+### Secrets Audit (DO-8.2)
+- `.env.example` + `.env.docker` di repo hanya placeholder (mis. `SECRET_KEY=CHANGE_ME_...`), no real secret.
+- `.env`, `.env.production`, `.env.docker` pattern di-ignore via `.gitignore` (`.env` + `.env.*`, kecuali `!.env.example` & `!.env.docker`).
+- **Temuan**: `SECRET_KEY` asli pernah ter-commit di `.env.docker` pada Sprint 3 (commit `5920a41`) lalu diganti placeholder. Secret production **sudah berbeda** dari nilai bocor (ter-rotate, len 66), jadi tidak ter-eksploitasi. History rewrite belum dilakukan (high-risk untuk clone tim) — dicatat sebagai utang teknis di `docs/release-notes.md`.
+- Var rahasia aktual bernama `SECRET_KEY` (JWT signing) + `DB_PASSWORD`; di-set di `/opt/temuin/.env`, tidak masuk log/response.
 
-### Security Headers
-Backend middleware tambah:
+### Security Headers (DO-8.4)
+Middleware di tiap service (`app/main.py`):
 - `X-Content-Type-Options: nosniff`
 - `X-Frame-Options: DENY`
-- `Strict-Transport-Security: max-age=31536000; includeSubDomains` (HTTPS only)
-- `Content-Security-Policy: default-src 'self'` minimum
+- `Strict-Transport-Security: max-age=63072000; includeSubDomains` (tanpa `preload`)
+- `Content-Security-Policy` **docs-aware**: strict `default-src 'self'; frame-ancestors 'none'` untuk path biasa; dilonggarkan khusus `/docs`, `/redoc`, `/openapi.json` (izinkan `cdn.jsdelivr.net`) supaya Swagger UI tetap jalan.
+- `/metrics` di-`include_in_schema=False` (DO-8.6 swagger cleanup) bersama endpoint internal cross-service auth.
 
 ### Input Validation
 Pydantic schema dengan `field_validator`:
-- Email: regex `@itk.ac.id$`
+- Email: regex `@([a-z0-9-]+\.)*itk\.ac\.id\Z` (anchored `\Z` + `.strip()` agar tidak bisa di-bypass trailing newline; subdomain ITK diterima)
 - Password: min 8 char, mengandung huruf dan angka
-- String fields: max length sesuai kebutuhan (title 200, description 2000)
-- Numeric: bound check (price 0..999_999_999, kalau ada)
+- String fields: max length sesuai kebutuhan (title 200, description 2000), name 2..200 (strip)
+- Error body 422 dinormalkan jadi `{"detail": "<string>"}` via exception handler (konsisten dengan kontrak frontend)
 
 ## Artefak Kunci
 

--- a/temuin-docs/06-sprints/sprint-08.md
+++ b/temuin-docs/06-sprints/sprint-08.md
@@ -32,12 +32,12 @@ Tutup celah security yang disinggung Modul 15, finalisasi dokumen, siapkan demo 
 
 | ID | Task | Priority | Estimate | Depends On | Status | Branch/Ref | Notes |
 |----|------|----------|----------|------------|--------|------------|-------|
-| DO-8.1 | Image hardening: backend Dockerfile pakai `USER appuser` (uid 1000), frontend nginx `--user 101:101` (DEC-018) | High | 2h | DO-7.5 | todo | - | Modul 15: image security |
-| DO-8.2 | Audit `.env*` files: pastikan `.env`, `.env.production`, `.env.docker` di `.gitignore`. `git log --all --full-history -- .env*` tidak nemu real secret | High | 2h | DO-8.1 | todo | - | Modul 15: secret leak prevention |
-| DO-8.3 | Final deployment ke Tencent VPS dengan tag v1.0.0 + cleanup environment | High | 2h | DO-8.2, BE-8.6 | todo | - | Modul 15: production-ready release. Container running, /api/status all up |
-| DO-8.4 | Backup video demo 5 menit (rekam screen seluruh flow utama untuk safety net UAS) | Medium | 2h | DO-8.3 | todo | - | Modul 15: backup demo. Upload ke Google Drive, link di `docs/final-checklist.md` |
-| DO-8.5 | Git tag v1.0.0 + buat `docs/release-notes.md` (highlights, migration notes, known limitations) | Medium | 1h | DO-8.3 | todo | - | Modul 15: final release. Push tag ke remote |
-| DO-8.6 | Final verification checklist + verify deployment docs sinkron dengan reality | Medium | 1h | DO-8.5 | todo | - | Modul 15: operations guide validation |
+| DO-8.1 | Image hardening: backend Dockerfile pakai `USER appuser` (uid 1000), frontend nginx `--user 101:101` (DEC-018) | High | 2h | DO-7.5 | done | PR #122 | Backend 3 service uid 1000, frontend `nginxinc/nginx-unprivileged` uid 101 listen 8080. Port 80->8080 disinkronkan (gateway upstream + compose). Verified production: `docker exec id -u` = 1000/101 |
+| DO-8.2 | Audit `.env*` files: pastikan `.env`, `.env.production`, `.env.docker` di `.gitignore`. `git log --all --full-history -- .env*` tidak nemu real secret | High | 2h | DO-8.1 | done | PR #122 | `.gitignore` benar, `.env.docker` placeholder. Temuan: `SECRET_KEY` asli pernah ke-commit (Sprint 3, `5920a41`) tapi prod pakai secret beda (ter-rotate, aman). History rewrite ditunda (high-risk), dicatat di `docs/release-notes.md` |
+| DO-8.3 | Final deployment ke Tencent VPS dengan tag v1.0.0 + cleanup environment | High | 2h | DO-8.2, BE-8.6 | in_progress | PR #122 (CD) | Deploy via CD auto-deploy (merge #122) + verified: 6 container healthy non-root, `/api/status` 3 up, `/` 200. Disk cleanup 70%->55% (prune dangling+build cache). Tag v1.0.0 pending (lihat DO-8.5) |
+| DO-8.4 | Backup video demo 5 menit (rekam screen seluruh flow utama untuk safety net UAS) | Medium | 2h | DO-8.3 | in_progress | docs/devops/sprint-08-do | Skrip alur demo `docs/demo-script.md` siap. Rekaman video + upload Google Drive manual oleh user, link di `docs/final-checklist.md` |
+| DO-8.5 | Git tag v1.0.0 + buat `docs/release-notes.md` (highlights, migration notes, known limitations) | Medium | 1h | DO-8.3 | in_progress | PR #122 | `docs/release-notes.md` done (merged PR #122). Git tag v1.0.0 + push tag pending konfirmasi user |
+| DO-8.6 | Final verification checklist + verify deployment docs sinkron dengan reality | Medium | 1h | DO-8.5 | done | docs/devops/sprint-08-do | `devops-architecture.md` + `operations-guide.md` disinkronkan dgn reality: image hardening (uid 1000/101), security headers docs-aware CSP, port 8080, CD gateway reload, 6 container |
 
 ## Lead QA & Docs (@raniayudewi)
 


### PR DESCRIPTION
## Ringkasan
Update dokumentasi DevOps Sprint 8 setelah deploy production (DO-8.1/8.2/8.3 live via PR #122).

## Perubahan
- **sprint-08.md**: status DO-8.1/8.2/8.6 -> `done`, DO-8.3/8.4/8.5 -> `in_progress` (sisa: git tag v1.0.0 + rekam video, butuh user).
- **docs/demo-script.md** (baru, DO-8.4): skrip alur demo 5 menit untuk backup video UAS. Rekaman + upload manual oleh user.
- **devops-architecture.md** (DO-8.6): sinkronkan section Security Sprint 8 dengan reality — image hardening uid 1000/101, CSP docs-aware, port frontend 8080, CD gateway reload, secrets audit (temuan secret history).
- **operations-guide.md**: koreksi ''kelima'' -> ''keenam'' container (gateway).

## Verifikasi production (DO-8.3)
- 6 container healthy, non-root (auth/item/engagement uid 1000, frontend uid 101)
- `/api/status` 3 service up, frontend `/` 200
- Disk cleanup 70% -> 55%

## Belum dikerjakan (nunggu user)
- DO-8.5 git tag v1.0.0 + push tag
- DO-8.4 rekaman video + upload Drive